### PR TITLE
Consider the exact number of days to stay in risk level

### DIFF
--- a/scripts/promote-tracks.py
+++ b/scripts/promote-tracks.py
@@ -89,7 +89,7 @@ def check_and_promote(snap_info, dry_run: bool):
 
         if (
             released_at_date
-            and (now - released_at_date).days > DAYS_TO_STAY_IN_RISK[risk]
+            and (now - released_at_date).days >= DAYS_TO_STAY_IN_RISK[risk]
             and channels.get(f"{track}/{risk}", {}).get("revision")
             != channels.get(f"{track}/{next_risk}", {}).get("revision")
         ):


### PR DESCRIPTION
The `.days` field only returns full days. Hence, checking for `>` would wait one day more than specified.