### PR TITLE
Validated promotion k8s-snap revisions can be upgraded to

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -1,0 +1,22 @@
+name: Inclusive Naming, Linting, and Unit Tests
+on: 
+  - pull_request
+
+jobs:
+  call-inclusive-naming-check:
+    name: Inclusive Naming
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
+    with:
+      fail-on-error: "true"
+
+  lint-unit:
+    name: Lint and Unit Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install tox
+      - name: Unit, Lint, Static Analysis
+        run: tox -vve unit,lint,static

--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -12,6 +12,8 @@ jobs:
   lint-unit:
     name: Lint and Unit Tests
     runs-on: ubuntu-22.04
+    env:
+      TERM: xterm-256color
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,4 +21,4 @@ jobs:
           python-version: "3.12"
       - run: pip install tox
       - name: Unit, Lint, Static Analysis
-        run: tox -vve unit,lint,static
+        run: tox -vve unit,lint,static -- --color=yes

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -9,6 +9,24 @@ on:
         default: false
         description: |-
           If true, it will not trigger the builds, just print which would be built
+      days_in_edge_risk:
+        type: number
+        required: false
+        default: 1
+        description: |-
+          The number of days in edge risk to consider for promotion
+      days_in_beta_risk:
+        type: number
+        required: false
+        default: 3
+        description: |-
+          The number of days in beta risk to consider for promotion
+      days_in_candidate_risk:
+        type: number
+        required: false
+        default: 5
+        description: |-
+          The number of days in candidate risk to consider for promotion
   pull_request:
     
   schedule:
@@ -24,6 +42,7 @@ jobs:
       proposals: ${{ steps.propose-promotions.outputs.proposals }}
     env:
       LPCREDS_B64: ${{ secrets.LP_CREDS }}
+      ARGS: ''
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
@@ -36,10 +55,18 @@ jobs:
           cache: 'pip'
       - run: pip install tox
       - run: 'echo $LPCREDS_B64 | base64 --decode > lp_creds'
+      - name: Assemble Dispatch Arguments
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          ARGS="${{ github.event.inputs.dry_run && '--dry-run' || '' }}"
+          ARGS="$ARGS --days-in-edge-risk=${{ github.event.inputs.days_in_edge_risk }}"
+          ARGS="$ARGS --days-in-beta-risk=${{ github.event.inputs.days_in_beta_risk }}"
+          ARGS="$ARGS --days-in-candidate-risk=${{ github.event.inputs.days_in_candidate_risk }}"
+          echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions
         run: |
-          LPCREDS=./lp_creds tox -e promote -- propose --gh-action
+          LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   test-proposal:
     needs: promotion-proposal
     strategy:

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -27,6 +27,18 @@ on:
         default: 5
         description: |-
           The number of days in candidate risk to consider for promotion
+      ignore_tracks:
+        type: string
+        required: false
+        default: ''
+        description: |-
+          A space separated list of tracks to ignore when proposing promotions
+      ignore_architectures:
+        type: string
+        required: false
+        default: ''
+        description: |-
+          A space separated list of architectures to ignore when proposing promotions
   pull_request:
     
   schedule:
@@ -59,9 +71,11 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           ARGS="${{ github.event.inputs.dry_run && '--dry-run' || '' }}"
-          ARGS="$ARGS --days-in-edge-risk=${{ github.event.inputs.days_in_edge_risk }}"
-          ARGS="$ARGS --days-in-beta-risk=${{ github.event.inputs.days_in_beta_risk }}"
-          ARGS="$ARGS --days-in-candidate-risk=${{ github.event.inputs.days_in_candidate_risk }}"
+          ARGS="$ARGS --days-in-edge-risk ${{ github.event.inputs.days_in_edge_risk }}"
+          ARGS="$ARGS --days-in-beta-risk ${{ github.event.inputs.days_in_beta_risk }}"
+          ARGS="$ARGS --days-in-candidate-risk ${{ github.event.inputs.days_in_candidate_risk }}"
+          ARGS="$ARGS --ignore-tracks ${{ github.event.inputs.ignore_tracks }}"
+          ARGS="$ARGS --ignore-arches ${{ github.event.inputs.ignore_architectures }}"
           echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -2,6 +2,15 @@ name: Promote tracks
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+        description: |-
+          If true, it will not trigger the builds, just print which would be built
+  pull_request:
+    
   schedule:
     - cron: '0 0 * * *'  # Runs every midnight
 
@@ -9,26 +18,43 @@ permissions:
   contents: read
 
 jobs:
-  promotion:
+  promotion-proposal:
     runs-on: ubuntu-latest
+    outputs:
+      proposals: ${{ steps.propose-promotions.outputs.proposals }}
     env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}
+      LPCREDS_B64: ${{ secrets.LP_CREDS }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
-      - name: Checking out repo
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: pip install -r scripts/requirements.txt
-      - name: Install snapcraft
+      - run: pip install tox
+      - run: 'echo $LPCREDS_B64 | base64 --decode > lp_creds'
+      - name: Propose Promotions
+        id: propose-promotions
         run: |
-          sudo snap install snapcraft --classic
-      - name: Run track promotion
-        run: |
-          ./scripts/promote_tracks.py
+          LPCREDS=./lp_creds tox -e promote -- propose --gh-action
+  test-proposal:
+    needs: promotion-proposal
+    strategy:
+      fail-fast: false   # Don't fail the entire matrix if one proposal fails
+      matrix:
+        include: ${{ fromJson(needs.promotion-proposal.outputs.proposals) }}
+    uses: ./.github/workflows/upgrade-proposal-test.yaml
+    with:
+      branch: ${{ matrix.branch }}
+      dry_run: ${{ inputs.dry_run || github.event_name == 'pull_request'}}
+      lxd-images: ${{ toJson(matrix.lxd-images) }}
+      proposal-name: ${{ matrix.name }}
+      revision: ${{ matrix.revision }}
+      runner-labels: ${{ toJson(matrix.runner-labels) }}
+      snap-channel: ${{ matrix.snap-channel }}
+      upgrade-channels: ${{ toJson(matrix.upgrade-channels) }}
+    secrets:
+      SNAPSTORE_AUTH_TOKEN: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}

--- a/.github/workflows/rebuild-release-branch.yaml
+++ b/.github/workflows/rebuild-release-branch.yaml
@@ -42,7 +42,6 @@ jobs:
           cache: 'pip'
       - run: pip install -r scripts/requirements.txt
       - run: 'echo $LPCREDS_B64 | base64 --decode > lp_creds'
-        shell: bash
       - name: Rebuild Branches
         run: |
           LPCREDS=./lp_creds scripts/request_builds.py --branch ${{ inputs.branches }}${{ inputs.dry_run && ' --dry-run' || '' }}

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -109,8 +109,8 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}
       run: |
-          tox -e promote --                               \
-          ${{ inputs.DRY_RUN }} && ' --dry-run' || '' }}  \
-          promote                                         \
-          --snap-revision="${{ inputs.revision }}"        \
+          tox -e promote -- \
+          ${{ inputs.dry_run && ' --dry-run' || '' }} \
+          promote \
+          --snap-revision="${{ inputs.revision }}" \
           --snap-channel="${{ inputs.snap-channel }}"

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -43,7 +43,7 @@ on:
       SNAPSTORE_AUTH_TOKEN:
         required: true
 jobs:
-  test-proposal: 
+  test-proposal:
     name: Integration Test ${{ inputs.proposal-name }} ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
@@ -51,6 +51,8 @@ jobs:
         # a unique runner for each lxd-image and upgrade-path
         lxd-image: ${{ fromJSON(inputs.lxd-images) }}
         upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
+    env:
+      ARTIFACT_NAME: promotion-test-$${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
     steps:
       - uses: step-security/harden-runner@v2
         with:
@@ -68,7 +70,7 @@ jobs:
           sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'          
+          sg lxd -c 'lxc version'
       - name: Run promotion tests
         env:
           TEST_SUBSTRATE: lxd
@@ -85,11 +87,12 @@ jobs:
         run: |
           tar -czvf inspection-reports.tar.gz -C $HOME inspection-reports
           tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" | sed 's/:/-/g' >> $GITHUB_ENV
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: promotion-test-$${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
   promote-proposal:
     name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -1,0 +1,116 @@
+name: Upgrade Proposal Test
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch of the k8s-snap to use for testing the proposal'
+        required: true
+        type: string
+      dry_run:
+        description: 'If true, it will trigger the test, but not promote on success'
+        required: false
+        type: boolean
+      lxd-channel:
+        description: 'The LXD channel to use for testing the proposal'
+        default: '5.21/stable'
+        type: string
+      lxd-images:
+        description: 'The LXD images to use for testing the proposal'
+        required: true
+        type: string
+      proposal-name:
+        description: 'The name of the proposal to test'
+        required: true
+        type: string
+      revision:
+        description: 'The snap revision to promote'
+        required: true
+        type: string
+      runner-labels:
+        description: 'The github runner-label for this job'
+        required: true
+        type: string
+      snap-channel:
+        description: 'The channels to promote the snap to'
+        required: true
+        type: string
+      upgrade-channels:
+        description: 'The upgrade paths to test'
+        required: true
+        type: string
+    secrets:
+      SNAPSTORE_AUTH_TOKEN:
+        required: true
+jobs:
+  test-proposal: 
+    name: Integration Test ${{ inputs.proposal-name }} ${{ matrix.lxd-image}}
+    runs-on: ${{ fromJson(inputs.runner-labels) }}
+    strategy:
+      matrix:
+        # a unique runner for each lxd-image and upgrade-path
+        lxd-image: ${{ fromJSON(inputs.lxd-images) }}
+        upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install lxd and tox
+        run: |
+          sudo apt update
+          sudo apt install -y tox
+          sudo snap install lxd --channel ${{ inputs.lxd-channel }} || true
+          sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd $USER
+          sg lxd -c 'lxc version'          
+      - name: Run promotion tests
+        env:
+          TEST_SUBSTRATE: lxd
+          TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
+          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
+        run: |
+          tox -e promote -- \
+            ${{ inputs.dry_run && ' --dry-run' || '' }} \
+            test \
+            --branch="${{ inputs.branch }}"
+      - name: Prepare inspection reports
+        if: failure()
+        run: |
+          tar -czvf inspection-reports.tar.gz -C $HOME inspection-reports
+          tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: promotion-test-$${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
+          path: ${{ github.workspace }}/inspection-reports.tar.gz
+  promote-proposal:
+    name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}
+    runs-on: ${{ fromJson(inputs.runner-labels) }}
+    needs: test-proposal
+    steps:
+    - uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - run: pip install tox
+    - name: Promote
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}
+      run: |
+          tox -e promote --                               \
+          ${{ inputs.DRY_RUN }} && ' --dry-run' || '' }}  \
+          promote                                         \
+          --snap-revision="${{ inputs.revision }}"        \
+          --snap-channel="${{ inputs.snap-channel }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B404","B603"]
+
+[tool.mypy]
+ignore_missing_imports = true
+explicit_package_bases = true
+namespace_packages = true

--- a/scripts/ensure_snap_builds.py
+++ b/scripts/ensure_snap_builds.py
@@ -32,9 +32,8 @@ def ensure_snap_channels(
         channels += [f"{name}/edge"]
 
     LOG.info("Ensure snap channels %s for ver %s in snapstore", ",".join(channels), ver)
-    if not dry_run:
-        for channel in channels:
-            snapstore.ensure_track(util.SNAP_NAME, channel)
+    for channel in channels:
+        (not dry_run) and snapstore.ensure_track(util.SNAP_NAME, channel)
     return channels
 
 
@@ -122,7 +121,8 @@ def ensure_lp_recipe(
             updated |= {key} if diff else set()
             if diff:
                 LOG.info("  Update %s: %s -> %s", key, lp_value, value)
-                (not dry_run) and setattr(recipe, key, value)
+                if not dry_run:
+                    setattr(recipe, key, value)
 
         if updated and not dry_run:
             recipe.lp_save()

--- a/scripts/ensure_snap_builds.py
+++ b/scripts/ensure_snap_builds.py
@@ -68,7 +68,7 @@ def ensure_lp_recipe(
     )
     client = lp.client()
     lp_project = client.projects[util.SNAP_NAME]
-    lp_owner = client.people[util.LP_OWNER]
+    lp_owner = client.people[lp.OWNER]
     lp_repo = client.git_repositories.getDefaultRepository(target=lp_project)
     lp_ref = lp_repo.getRefByPath(path=flavor_branch)
     lp_archive = client.archives.getByReference(reference="ubuntu")

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -175,6 +175,8 @@ def create_proposal(args):
 
 def _create_arch_proposals(arch, channels: dict[str, Channel], args):
     proposals = []
+    ignored_tracks = IGNORE_TRACKS + getattr(args, "ignore_tracks", [])
+    ignored_arches = getattr(args, "ignore_arches", [])
     days_to_stay_in_risk = {
         "edge": args.days_in_edge_risk,
         "beta": args.days_in_beta_risk,
@@ -197,8 +199,12 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             chan_log.debug("Skipping promoting stable")
             continue
 
-        if track in IGNORE_TRACKS:
+        if track in ignored_tracks:
             chan_log.debug("Skipping ignored track")
+            continue
+
+        if arch in ignored_arches:
+            chan_log.debug("Skipping ignored architecture")
             continue
 
         now = datetime.datetime.now(datetime.timezone.utc)
@@ -312,6 +318,18 @@ def main():
         type=int,
         help="The number of days a revision stays in candidate risk",
         default=DAYS_TO_STAY_IN_CANDIDATE,
+    )
+    propose_args.add_argument(
+        "--ignore-tracks",
+        nargs="+",
+        help="Tracks to ignore when proposing revisions",
+        default=[],
+    )
+    propose_args.add_argument(
+        "--ignore-arches",
+        nargs="+",
+        help="Architectures to ignore when proposing revisions",
+        default=[],
     )
     propose_args.set_defaults(func=create_proposal)
 

--- a/scripts/request_builds.py
+++ b/scripts/request_builds.py
@@ -25,7 +25,7 @@ def rebuild_branches(branches: Iterable[str], args: argparse.Namespace):
     * Ensure LP recipes are pushing to the correct snap channels.
     """
     client = lp.client()
-    owner = client.people[util.LP_OWNER]
+    owner = client.people[lp.OWNER]
     for branch in branches:
         LOG.info("Cloning tip branch %s", branch)
         with repo.clone(util.SNAP_REPO, branch) as dir:

--- a/scripts/request_builds.py
+++ b/scripts/request_builds.py
@@ -53,7 +53,7 @@ def rebuild_branches(branches: Iterable[str], args: argparse.Namespace):
                     )
 
 
-def tip_branches(branches: Iterable[str]) -> Generator[None, str, None]:
+def tip_branches(branches: Iterable[str]) -> Generator[str, None, None]:
     for branch in branches:
         if not util.TIP_BRANCH.match(branch):
             LOG.warning(

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
+actions_toolkit==0.1.15
 distro==1.9.0
 httplib2==0.22.0
 launchpadlib==1.11.0
@@ -5,4 +6,5 @@ lazr-restfulclient==0.14.6
 lazr-uri==1.0.6
 semver==3.0.2
 six==1.16.0
+tox==4.20.0
 wadllib==1.3.6

--- a/scripts/util/gh.py
+++ b/scripts/util/gh.py
@@ -1,0 +1,13 @@
+REPO_RUNNER_LABEL_MAP = {
+    "amd64": "X64",
+    "arm64": "ARM64",
+}
+
+
+def arch_to_gh_labels(arch: str, self_hosted: bool = False) -> list[str]:
+    labels = []
+    if label := REPO_RUNNER_LABEL_MAP.get(arch):
+        labels.append(label)
+    if self_hosted:
+        labels.append("self-hosted")
+    return labels

--- a/scripts/util/lp.py
+++ b/scripts/util/lp.py
@@ -4,6 +4,8 @@ from functools import cache
 
 from launchpadlib.launchpad import Launchpad
 
+OWNER: str = "containers"
+
 
 @cache
 def client():
@@ -27,3 +29,18 @@ def client():
         )
     else:
         raise ValueError("No launchpad credentials found")
+
+
+def snap_by_owner(snap: str):
+    """Return the owner object for a given owner name."""
+    lp_client = client()
+    return lp_client.snaps.findByStoreName(
+        owner=lp_client.people[OWNER], store_name=snap
+    )
+
+
+def branch_from_track(snap, track):
+    """Return the branch name for a given track."""
+    for recipe in snap_by_owner(snap):
+        if any(chan.split("/")[0] == track for chan in recipe.store_channels):
+            return recipe.git_ref_link.split("+ref/")[1]

--- a/scripts/util/lp.py
+++ b/scripts/util/lp.py
@@ -10,8 +10,8 @@ OWNER: str = "containers"
 @cache
 def client():
     """Use launchpad credentials to interact with launchpad."""
-    cred_file = os.environ.get("LPCREDS", None)
-    creds_local = os.environ.get("LPLOCAL", None)
+    cred_file = os.getenv("LPCREDS")
+    creds_local = os.getenv("LPLOCAL")
     if cred_file:
         parser = ConfigParser()
         parser.read(cred_file)

--- a/scripts/util/repo.py
+++ b/scripts/util/repo.py
@@ -1,17 +1,21 @@
 import contextlib
 import logging
+import os
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Generator
 
-from util.util import parse_output
-
 LOG = logging.getLogger(__name__)
+
+
+def _parse_output(*args, **kwargs) -> str:
+    return subprocess.check_output(*args, text=True, **kwargs).strip()
 
 
 @contextlib.contextmanager
 def clone(
-    repo_url: str, repo_tag: str, shallow: bool = True
+    repo_url: str, repo_tag: str | None = None, shallow: bool = True
 ) -> Generator[Path, Any, Any]:
     """
     Clone a git repository on a temporary directory and return the directory.
@@ -25,11 +29,13 @@ def clone(
     """
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        cmd = ["git", "clone", repo_url, tmpdir, "-b", repo_tag]
+        cmd = ["git", "clone", repo_url, tmpdir]
+        if repo_tag:
+            cmd.extend(["-b", repo_tag])
         if shallow:
             cmd.extend(["--depth", "1"])
         LOG.info("Cloning %s @ %s (shallow=%s)", repo_url, repo_tag, shallow)
-        parse_output(cmd)
+        _parse_output(cmd)
         yield Path(tmpdir)
 
 
@@ -41,20 +47,38 @@ def is_branch(repo: str, branch_name: str) -> bool:
 def _commit_sha1_per_branch(
     repo: str, branch_name: None | str = None
 ) -> Dict[str, str]:
-    out = parse_output(
+    out = _parse_output(
         ["git", "ls-remote", "--heads", repo] + ([branch_name] if branch_name else [])
     )
-    return dict(tuple(reversed(line.split(maxsplit=1))) for line in out.splitlines())
+    vals = dict(line.split(maxsplit=1) for line in out.splitlines())
+    return {v: k for k, v in vals.items()}
 
 
-def which_branch(dir: Path) -> str:
-    return parse_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=dir)
+def default_branch(repo: str) -> str:
+    out = _parse_output(["git", "ls-remote", "--symref", repo, "HEAD"])
+    default = next(line for line in out.splitlines() if "ref:" in line)
+    return default.split()[1].split("refs/heads/")[1]
 
 
-def commit_sha1(dir: Path) -> str:
-    return parse_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=dir)
+def commit_sha1(dir: os.PathLike, short: bool = False) -> str:
+    cmd = ["git", "rev-parse"] + (short and ["--short"] or []) + ["HEAD"]
+    return _parse_output(cmd, cwd=dir).strip()
 
 
 def ls_branches(repo: str) -> Generator[str, None, None]:
     for ref in _commit_sha1_per_branch(repo):
         yield "/".join(ref.split("/")[2:])
+
+
+def ls_tree(dir: os.PathLike, patch_dir: None | os.PathLike = None) -> list[str]:
+    return sorted(
+        subprocess.check_output(
+            ["git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD"] + [patch_dir]
+            if patch_dir
+            else [],
+            text=True,
+            cwd=dir,
+        )
+        .strip()
+        .splitlines()
+    )

--- a/scripts/util/util.py
+++ b/scripts/util/util.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 import re
-import subprocess
 from pathlib import Path
 
 import semver
+import util.repo as repo
 
 LOG = logging.getLogger(__name__)
 SNAP_NAME: str = "k8s"
@@ -15,13 +15,8 @@ TIP_BRANCH = re.compile(r"^(?:main)|^(?:release-\d+\.\d+)$")
 
 def flavors(dir: str) -> list[str]:
     patch_dir = Path("build-scripts/patches")
-    output = parse_output(
-        ["git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD", patch_dir],
-        cwd=dir,
-    )
-    patches = set(
-        Path(f).relative_to(patch_dir).parents[0] for f in output.splitlines()
-    )
+    output = repo.ls_tree(dir, patch_dir)
+    patches = set(Path(f).relative_to(patch_dir).parents[0] for f in output)
     return sorted([p.name for p in patches] + ["classic"])
 
 
@@ -31,18 +26,10 @@ def recipe_name(flavor: str, ver: semver.Version, tip: bool) -> str:
     return f"{SNAP_NAME}-snap-{ver.major}.{ver.minor}-{flavor}"
 
 
-def parse_output(*args, **kwargs) -> str:
-    return (
-        subprocess.run(*args, capture_output=True, check=True, **kwargs)
-        .stdout.decode()
-        .strip()
-    )
-
-
 def setup_logging(args: argparse.Namespace):
     FORMAT = "%(name)20s %(asctime)s %(levelname)8s - %(message)s"
     logging.basicConfig(format=FORMAT)
-    if args.loglevel:
+    if args.loglevel != logging.getLevelName(LOG.root.level):
         LOG.root.setLevel(level=args.loglevel.upper())
 
 

--- a/scripts/util/util.py
+++ b/scripts/util/util.py
@@ -9,7 +9,6 @@ import util.repo as repo
 LOG = logging.getLogger(__name__)
 SNAP_NAME: str = "k8s"
 SNAP_REPO: str = "https://github.com/canonical/k8s-snap.git/"
-LP_OWNER: str = "containers"
 TIP_BRANCH = re.compile(r"^(?:main)|^(?:release-\d+\.\d+)$")
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,2 @@
+freezegun
+pytest

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -1,0 +1,84 @@
+import unittest.mock as mock
+
+import pytest
+from freezegun import freeze_time
+from promote_tracks import check_and_promote
+
+
+@pytest.fixture
+def release_revision():
+    with mock.patch("promote_tracks.release_revision") as mocked:
+        yield mocked
+
+
+def _create_channel(track: str, risk: str, revision: int):
+    return {
+        "channel": {
+            "architecture": "amd64",
+            "name": f"{track}/{risk}",
+            "released-at": "2000-01-01T00:00:00.0+00:00",
+            "risk": risk,
+            "track": track,
+        },
+        "created-at": "2000-01-01T00:00:00.000000+00:00",
+        "download": {},
+        "revision": revision,
+        "type": "app",
+        "version": "v1.31.0",
+    }
+
+
+def _make_channel_map(track: str, risk: str, has_stable: bool = False):
+    snap_info = {"channel-map": [_create_channel(track, risk, 2)]}
+    if has_stable:
+        snap_info["channel-map"].append(_create_channel(track, "stable", 1))
+    return snap_info
+
+
+@pytest.mark.parametrize(
+    "risk, next_risk, now",
+    [
+        ("edge", "beta", "2000-01-02"),
+        ("beta", "candidate", "2000-01-04"),
+        ("candidate", "stable", "2000-01-06"),
+    ],
+)
+def test_risk_promotable(risk, next_risk, now, release_revision):
+    with freeze_time(now):
+        check_and_promote(
+            _make_channel_map("tracky", risk, has_stable=True), dry_run=False
+        )
+    release_revision.assert_called_once_with(2, f"tracky/{next_risk}")
+
+
+@pytest.mark.parametrize(
+    "risk, now",
+    [("edge", "2000-01-01"), ("beta", "2000-01-03"), ("candidate", "2000-01-05")],
+)
+def test_risk_not_yet_promotable(risk, now, release_revision):
+    with freeze_time(now):
+        check_and_promote(_make_channel_map("tracky", risk), dry_run=False)
+    release_revision.assert_not_called(), "Channel should not be promoted too soon"
+
+
+@pytest.mark.parametrize(
+    "risk, now",
+    [("candidate", "2000-01-06")],
+)
+def test_risk_promotable_without_stable(risk, now, release_revision):
+    with freeze_time(now):
+        check_and_promote(_make_channel_map("tracky", risk), dry_run=False)
+    (
+        release_revision.assert_not_called(),
+        "Candidate track should not be promoted if stable is missing",
+    )
+
+
+@pytest.mark.parametrize(
+    "risk, now",
+    [("edge", "2000-01-06")],
+)
+def test_latest_track(risk, now, release_revision):
+    with freeze_time(now):
+        check_and_promote(_make_channel_map("latest", risk), dry_run=False)
+    release_revision.assert_not_called(), "Latest track should not be promoted"

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -22,7 +22,7 @@ def _create_channel(track: str, risk: str, revision: int):
         "channel": {
             "architecture": "amd64",
             "name": f"{track}/{risk}",
-            "released-at": "2000-01-01T00:00:00.0+00:00",
+            "released-at": "2000-01-01T00:00:00.000000+00:00",
             "risk": risk,
             "track": track,
         },

--- a/tests/unit/util/test_lp.py
+++ b/tests/unit/util/test_lp.py
@@ -1,0 +1,53 @@
+import tempfile
+import unittest.mock as mock
+
+import pytest
+import util.lp as lp
+
+
+@pytest.fixture(autouse=True)
+def clear_lp_client_cache():
+    lp.client.cache_clear()
+
+
+@mock.patch("launchpadlib.launchpad.Launchpad.login_with")
+def test_create_client_with_file(mock_login):
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(b"[1]\nconsumer_key = some-key\n")
+        temp_file.flush()
+        with mock.patch.dict("os.environ", {"LPCREDS": temp_file.name}):
+            client = lp.client()
+            assert client, "Expected a client"
+            mock_login.assert_called_once_with(
+                application_name="some-key",
+                service_root="production",
+                version="devel",
+                credentials_file=temp_file.name,
+            )
+    assert lp.client.cache_info().misses == 1, "Expected a cache miss"
+    lp.client()
+    assert lp.client.cache_info().hits == 1, "Expected a cache hit"
+
+
+@mock.patch.dict("os.environ", {"LPLOCAL": "True"})
+@mock.patch("launchpadlib.launchpad.Launchpad.login_with")
+def test_create_client_with_local(mock_login):
+    client = lp.client()
+    assert client, "Expected a client"
+    mock_login.assert_called_once_with(
+        "localhost",
+        "production",
+        version="devel",
+    )
+
+    assert lp.client.cache_info().misses == 1, "Expected a cache miss"
+    lp.client()
+    assert lp.client.cache_info().hits == 1, "Expected a cache hit"
+
+
+def test_create_client_no_creds():
+    with pytest.raises(ValueError, match="No launchpad credentials found"):
+        lp.client()
+    with pytest.raises(ValueError, match="No launchpad credentials found"):
+        lp.client()
+    assert lp.client.cache_info().misses == 2, "Expected a cache miss"

--- a/tests/unit/util/test_repo.py
+++ b/tests/unit/util/test_repo.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import util.repo as repo
+
+THIS_REPO = "https://github.com/canonical/canonical-kubernetes-release-ci.git"
+DEFAULT_BRANCH = "main"
+
+
+def test_is_branch():
+    default = repo.default_branch(THIS_REPO)
+    assert repo.is_branch(THIS_REPO, default), "Default branch should undoubtedly exist"
+
+
+def test_clone():
+    default = repo.default_branch(THIS_REPO)
+    with repo.clone(THIS_REPO, default, True) as dir:
+        branch_sha1 = repo.commit_sha1(dir)
+        assert branch_sha1, "Expected a commit SHA1"
+    with repo.clone(THIS_REPO) as dir:
+        assert branch_sha1 == repo.commit_sha1(dir), "Expected same commit SHA1"
+        assert repo.commit_sha1(dir, short=True) in branch_sha1, "Expected short SHA1"
+
+
+def test_ls_branches():
+    default = repo.default_branch(THIS_REPO)
+    branches = repo.ls_branches(THIS_REPO)
+    assert default in branches, "Expected default branch in branches"
+
+
+def test_ls_tree():
+    this_path = Path(__file__).parent
+    paths = repo.ls_tree(this_path, "tests")
+    assert paths, "Expected some paths"

--- a/tests/unit/util/test_snapstore.py
+++ b/tests/unit/util/test_snapstore.py
@@ -1,0 +1,46 @@
+import json
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+import util.snapstore as snapstore
+
+
+@patch("util.snapstore.urlopen")
+def test_info_success(mock_urlopen):
+    # Mock the response from urlopen
+    context = mock_urlopen.return_value.__enter__.return_value
+    context.read.return_value = json.dumps({"name": "test-snap"}).encode("utf-8")
+
+    result = snapstore.info("test-snap")
+    assert result == {"name": "test-snap"}
+    mock_urlopen.assert_called_once()
+
+
+@patch("util.snapstore.urlopen")
+def test_info_http_error(mock_urlopen):
+    # Mock an HTTPError
+    mock_urlopen.side_effect = HTTPError(
+        url="http://test-url",
+        code=404,
+        msg="Not Found",
+        hdrs=None,  # type: ignore
+        fp=None,
+    )
+
+    with pytest.raises(HTTPError):
+        snapstore.info("non-existent-snap")
+
+
+@patch("util.snapstore.urlopen")
+def test_info_url_error(mock_urlopen):
+    # Mock a URLError
+    mock_urlopen.side_effect = URLError("Reason")
+
+    with pytest.raises(URLError):
+        snapstore.info("non-existent-snap")
+
+
+def test_ensure_track():
+    # Placeholder for ensure_track tests
+    snapstore.ensure_track("test-snap", "test-track")

--- a/tests/unit/util/test_util.py
+++ b/tests/unit/util/test_util.py
@@ -1,0 +1,53 @@
+import argparse
+import unittest.mock as mock
+
+import semver
+import util.util as util
+
+
+@mock.patch("util.repo.ls_tree")
+def test_flavors(mock_ls_tree):
+    mock_ls_tree.return_value = [
+        "build-scripts/patches/flavor1/patch1",
+        "build-scripts/patches/flavor2/patch2",
+    ]
+    expected = ["classic", "flavor1", "flavor2"]
+    result = util.flavors("some_dir")
+    assert result == expected
+
+
+def test_recipe_name_tip():
+    ver = semver.Version.parse("1.2.3")
+    flavor = "flavor1"
+    tip = True
+    expected = "k8s-snap-tip-flavor1"
+    result = util.recipe_name(flavor, ver, tip)
+    assert result == expected
+
+
+def test_recipe_name_non_tip():
+    ver = semver.Version.parse("1.2.3")
+    flavor = "flavor1"
+    tip = False
+    expected = "k8s-snap-1.2-flavor1"
+    result = util.recipe_name(flavor, ver, tip)
+    assert result == expected
+
+
+@mock.patch("argparse.ArgumentParser.parse_args")
+@mock.patch("util.util.setup_logging")
+def test_setup_arguments(mock_setup_logging, mock_parse_args):
+    mock_args = argparse.Namespace(dry_run=False, loglevel="INFO")
+    mock_parse_args.return_value = mock_args
+    parser = argparse.ArgumentParser()
+    args = util.setup_arguments(parser)
+    mock_setup_logging.assert_called_once_with(mock_args)
+    assert args == mock_args
+
+
+@mock.patch("util.util.LOG")
+def test_setup_logging(mock_logger):
+    mock_logger.root.level = 30  # WARNING
+    mock_args = argparse.Namespace(dry_run=False, loglevel="INFO")
+    util.setup_logging(mock_args)
+    mock_logger.root.setLevel.assert_called_once_with(level="INFO")

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,21 @@ passenv =
   PYTHONPATH
   TERM
 
+
+[testenv:promote]
+description = Execute the promote job
+passenv =
+  LPCREDS
+  GITHUB_OUTPUT
+  TEST_*
+  SNAPCRAFT_STORE_CREDENTIALS
+deps = 
+    -r{[vars]src_path}/requirements.txt
+commands =
+    python {toxinidir}/scripts/promote_tracks.py {posargs}
+
+
 [testenv:format]
-allowlist_externals = tox
 description = Apply coding style standards to code
 deps = 
     ruff
@@ -31,7 +44,6 @@ commands =
     ruff check --fix {[vars]all_path}
 
 [testenv:lint]
-allowlist_externals = tox
 description = Check code against coding style standards
 deps =
     black

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,72 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint, unit, static, coverage-report
+
+[vars]
+src_path = {toxinidir}/scripts
+tst_path = {toxinidir}/tests
+all_path = {[vars]tst_path} {[vars]src_path}
+
+[testenv]
+setenv =
+  PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
+passenv =
+  PYTHONPATH
+
+[testenv:format]
+allowlist_externals = tox
+description = Apply coding style standards to code
+deps = 
+    ruff
+    isort
+commands =
+    isort {[vars]all_path}
+    ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path}
+
+[testenv:lint]
+allowlist_externals = tox
+description = Check code against coding style standards
+deps =
+    black
+    codespell
+    isort
+    mypy
+    ruff
+    -r{toxinidir}/test_requirements.txt
+    -r{[vars]src_path}/requirements.txt
+commands =
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox
+    isort --check-only --diff {[vars]all_path}
+    ruff check --diff {[vars]all_path}
+    mypy {[vars]all_path} --check-untyped-defs
+
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    coverage[toml]
+    -r{toxinidir}/test_requirements.txt
+    -r{[vars]src_path}/requirements.txt
+setenv   =
+    PYTHONPATH = {env:PYTHONPATH}{:}{[vars]src_path}
+commands =
+    coverage run --source={[vars]src_path} \
+        -m pytest --ignore={[vars]tst_path}integration -vv \
+        --basetemp={envtmpdir} \
+        --tb native -s {posargs}
+    coverage report --show-missing
+
+
+[testenv:static]
+description = Run static analysis tests
+deps =
+    bandit[toml]
+commands =
+    bandit -c {toxinidir}/pyproject.toml -r {[vars]all_path}
+

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
   PY_COLORS=1
 passenv =
   PYTHONPATH
+  TERM
 
 [testenv:format]
 allowlist_externals = tox


### PR DESCRIPTION
### Overview

In order for `<track>/<risk>` to replace `<track>/<risk+1>`, We need to validate upgrades
* from `<track>/<risk+1>` to `<track>/<risk>`
* from `<track>/<highest>` to `<track>/<risk>`
* from `<prior-track>/<highest>` to `<track>/<risk>`

example)
promoting 1.31/edge -> 1.31/beta:
* validate 1.31/beta -> 1.31/edge  (ensures some revision on the beta channel gets a safe auto-refresh)
* validate 1.31/stable -> 1.31/edge (ensures some revision on a stable channel gets this rev as an auto-refresh)
* validate 1.30/stable -> 1.31/edge (ensure some revision on a prev stable gets this rev during channel switch)

### Details
* Add CI unit tests for "promote_tracks"
* Unifies logging of the promote_tracks job with the ensure_snap_builds job
* uses ruff for formatting, and ruff isort and mypy for linting
* Ensures promote_track channels are sorted by track then risk