### PR TITLE
Allow for 0-n args for ignored fields

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -83,7 +83,7 @@ jobs:
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   test-proposal:
     needs: promotion-proposal
-    name: Test ${{ matrix.revision }}
+    name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:
       fail-fast: false   # Don't fail the entire matrix if one proposal fails
       matrix:

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -83,6 +83,7 @@ jobs:
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   test-proposal:
     needs: promotion-proposal
+    name: Test ${{ matrix.revision }}
     strategy:
       fail-fast: false   # Don't fail the entire matrix if one proposal fails
       matrix:

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -44,7 +44,7 @@ on:
         required: true
 jobs:
   test-proposal:
-    name: Test ${{ inputs.proposal-name }} on ${{ matrix.lxd-image}}
+    name: ${{ matrix.lxd-image}} from ${{ join(matrix.upgrade-channel, ', to ')}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
       fail-fast: false

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -61,6 +61,7 @@ jobs:
           ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
           ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -74,13 +75,14 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
-          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
       - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
         env:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
           TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
+          TEST_DEFAULT_WAIT_RETRIES: 30
+          TEST_DEFAULT_WAIT_DELAY_S: 10
         run: |
           tox -e promote -- \
             ${{ inputs.dry_run && ' --dry-run' || '' }} \
@@ -96,6 +98,10 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
+      - name: Debugging session
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        uses: canonical/action-tmate@main
+        timeout-minutes: 10
   promote-proposal:
     name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}
     runs-on: ${{ fromJson(inputs.runner-labels) }}

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -44,7 +44,7 @@ on:
         required: true
 jobs:
   test-proposal:
-    name: ${{ matrix.lxd-image}} from ${{ join(matrix.upgrade-channel, ', to ')}}
+    name: ${{ join(matrix.upgrade-channel, ' to ')}} on ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
       fail-fast: false

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -61,9 +61,6 @@ jobs:
           ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
           ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
-      - uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -71,8 +68,7 @@ jobs:
           cache: 'pip'
       - name: Install lxd and tox
         run: |
-          sudo apt update
-          sudo apt install -y tox
+          pip install tox
           sudo snap install lxd --channel ${{ inputs.lxd-channel }} || true
           sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
           sudo lxd init --auto

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -44,7 +44,7 @@ on:
         required: true
 jobs:
   test-proposal:
-    name: Integration Test ${{ inputs.proposal-name }} ${{ matrix.lxd-image}}
+    name: Test ${{ inputs.proposal-name }} on ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
       fail-fast: false
@@ -79,7 +79,7 @@ jobs:
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
           echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
-      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{ env.ARCHITECTURE }}
+      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
         env:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -52,8 +52,12 @@ jobs:
         lxd-image: ${{ fromJSON(inputs.lxd-images) }}
         upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
     env:
-      ARTIFACT_NAME: promotion-test-$${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
+      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}
     steps:
+      - name: Update ARTIFACT_NAME
+        run: |
+          ARTIFACT_NAME=$ARTIFACT_NAME-$(echo ${{ matrix.lxd-image }} | sed 's/:/-/g')
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
       - uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
@@ -87,7 +91,6 @@ jobs:
         run: |
           tar -czvf inspection-reports.tar.gz -C $HOME inspection-reports
           tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
-          echo "ARTIFACT_NAME=$ARTIFACT_NAME" | sed 's/:/-/g' >> $GITHUB_ENV
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -47,16 +47,19 @@ jobs:
     name: Integration Test ${{ inputs.proposal-name }} ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
+      fail-fast: false
       matrix:
         # a unique runner for each lxd-image and upgrade-path
         lxd-image: ${{ fromJSON(inputs.lxd-images) }}
         upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
     env:
-      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}
+      ARCHITECTURE: ''
+      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
     steps:
       - name: Update ARTIFACT_NAME
         run: |
-          ARTIFACT_NAME=$ARTIFACT_NAME-$(echo ${{ matrix.lxd-image }} | sed 's/:/-/g')
+          ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
+          ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
       - uses: step-security/harden-runner@v2
         with:
@@ -75,7 +78,8 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
-      - name: Run promotion tests
+          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
+      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{ env.ARCHITECTURE }}
         env:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
@@ -89,8 +93,7 @@ jobs:
       - name: Prepare inspection reports
         if: failure()
         run: |
-          tar -czvf inspection-reports.tar.gz -C $HOME inspection-reports
-          tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+          tar -czvf ${{ github.workspace }}/inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: failure()

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -321,13 +321,13 @@ def main():
     )
     propose_args.add_argument(
         "--ignore-tracks",
-        nargs="+",
+        nargs="*",
         help="Tracks to ignore when proposing revisions",
         default=[],
     )
     propose_args.add_argument(
         "--ignore-arches",
-        nargs="+",
+        nargs="*",
         help="Architectures to ignore when proposing revisions",
         default=[],
     )

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -141,6 +141,10 @@ def _build_upgrade_channels(
             source_channels |= {source}
             break
 
+    if not source_channels:
+        LOG.info("Without anything to upgrade from, just bootstrap on %s", channel.name)
+        return [[channel.name]]
+
     # Only run tests on revision changes
     return [
         [source, channel.name]

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -252,13 +252,16 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
                     next_risk,
                 )
                 proposal = {}
+                proposal["arch"] = arch
                 proposal["branch"] = lp.branch_from_track(util.SNAP_NAME, track)
                 proposal["upgrade-channels"] = _build_upgrade_channels(
                     channel_info, channels
                 )
                 proposal["revision"] = revision
+                proposal["track"] = track
+                proposal["next-risk"] = next_risk
                 proposal["snap-channel"] = final_channel
-                proposal["name"] = f"{util.SNAP_NAME}-{track}-{next_risk}-{arch}"
+                proposal["name"] = f"{util.SNAP_NAME}-{track}/{next_risk}-{arch}"
                 proposal["runner-labels"] = gh.arch_to_gh_labels(arch, self_hosted=True)
                 proposal["lxd-images"] = [f"ubuntu:{series}" for series in SERIES]
                 proposals.append(proposal)

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -47,13 +47,16 @@ def _create_channel(
 def _expected_proposals(track, next_risk, risk, revision):
     return [
         {
-            "name": f"k8s-1.31-tracky-{next_risk}-amd64",
+            "arch": "amd64",
             "branch": MOCK_BRANCH,
             "lxd-images": ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"],
-            "runner-labels": ["X64", "self-hosted"],
-            "upgrade-channels": [[f"{track}/stable", f"{track}/{risk}"]],
-            "snap-channel": f"{track}/{next_risk}",
+            "name": f"k8s-1.31-tracky/{next_risk}-amd64",
+            "next-risk": next_risk,
             "revision": revision,
+            "runner-labels": ["X64", "self-hosted"],
+            "snap-channel": f"{track}/{next_risk}",
+            "track": track,
+            "upgrade-channels": [[f"{track}/stable", f"{track}/{risk}"]],
         }
     ]
 


### PR DESCRIPTION
### Overview

In order to run the promote workflow from the action, the `ignored-tracks` and `ignore-arches` should support an empty set of arguments.

See failed run:
* https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/11292884151

### Details
* Improves workflow names
* resolves issue when there is no prior snap reversion to upgrade from