### PR TITLE
Set minimum release for upgrade tests

### DIFF
--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -81,6 +81,8 @@ jobs:
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
           TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
+          # Upgrading from 1.30 is not supported.
+          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_DEFAULT_WAIT_RETRIES: 30
           TEST_DEFAULT_WAIT_DELAY_S: 10
         run: |


### PR DESCRIPTION
Requires: https://github.com/canonical/k8s-snap/pull/769

Note that the test will still fail until we ported the main branch to 1.31