### PR TITLE
Run all integration test for promotion

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -19,10 +19,6 @@ jobs:
       CHARMCRAFT_AUTH : ${{ secrets.CHARMCRAFT_AUTH }}
       LPCREDS_B64: ${{ secrets.LP_CREDS }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -76,7 +76,7 @@ jobs:
         id: propose-promotions
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
-  test-proposal-upgradesjjjjjjjjjjj:
+  test-proposal-upgrades:
     needs: promotion-proposal
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -50,10 +50,6 @@ jobs:
       LPCREDS_B64: ${{ secrets.LP_CREDS }}
       ARGS: ''
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -80,7 +76,7 @@ jobs:
         id: propose-promotions
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
-  test-proposal:
+  test-proposal-upgradesjjjjjjjjjjj:
     needs: promotion-proposal
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:

--- a/.github/workflows/rebuild-release-branch.yaml
+++ b/.github/workflows/rebuild-release-branch.yaml
@@ -6,7 +6,7 @@ on:
       branches:
         type: string
         required: false
-        default: ""  # defaults to all branches 
+        default: ""  # defaults to all branches
         description: |-
           Run on which k8s-snap branches.
           list all branches necessary by spaces.
@@ -29,10 +29,6 @@ jobs:
     env:
       LPCREDS_B64: ${{ secrets.LP_CREDS }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -43,25 +43,77 @@ on:
       SNAPSTORE_AUTH_TOKEN:
         required: true
 jobs:
-  test-proposal:
-    name: ${{ join(matrix.upgrade-channel, ' to ')}} on ${{ matrix.lxd-image}}
+#  test-proposal-upgrades:
+#    name: ${{ join(matrix.upgrade-channel, ' to ')}} on ${{ matrix.lxd-image}}
+#    runs-on: ${{ fromJson(inputs.runner-labels) }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        # a unique runner for each lxd-image and upgrade-path
+#        lxd-image: ${{ fromJSON(inputs.lxd-images) }}
+#        upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
+#    env:
+#      ARCHITECTURE: ''
+#      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
+#    steps:
+#      - name: Update ARTIFACT_NAME
+#        run: |
+#          ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
+#          ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
+#          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+#          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.12'
+#          cache: 'pip'
+#      - name: Install lxd and tox
+#        run: |
+#          pip install tox
+#          sudo snap install lxd --channel ${{ inputs.lxd-channel }} || true
+#          sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
+#          sudo lxd init --auto
+#          sudo usermod --append --groups lxd $USER
+#          sg lxd -c 'lxc version'
+#      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
+#        env:
+#          TEST_SUBSTRATE: lxd
+#          TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
+#          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+#          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
+#          # Upgrading from 1.30 is not supported.
+#          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
+#          TEST_DEFAULT_WAIT_RETRIES: 30
+#          TEST_DEFAULT_WAIT_DELAY_S: 10
+#          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
+#        run: |
+#          tox -e promote -- \
+#            ${{ inputs.dry_run && ' --dry-run' || '' }} \
+#            test \
+#            --branch="${{ inputs.branch }}"
+#      - name: Prepare inspection reports
+#        if: failure()
+#        run: |
+#          tar -czvf ${{ github.workspace }}/inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+#      - name: Upload test results
+#        uses: actions/upload-artifact@v4
+#        if: failure()
+#        with:
+#          name: ${{ env.ARTIFACT_NAME }}
+#          path: ${{ github.workspace }}/inspection-reports.tar.gz
+#      - name: Debugging session
+#        if: ${{ failure() && github.event_name == 'pull_request' }}
+#        uses: canonical/action-tmate@main
+#        timeout-minutes: 10
+  test-proposal-e2e:
+    #needs: test-proposal-upgrades
+    name: ${{ matrix.snap-channel, ' to ')}} on ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        # a unique runner for each lxd-image and upgrade-path
         lxd-image: ${{ fromJSON(inputs.lxd-images) }}
-        upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
-    env:
-      ARCHITECTURE: ''
-      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
     steps:
-      - name: Update ARTIFACT_NAME
-        run: |
-          ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
-          ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
-          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
-          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -75,21 +127,16 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
-      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
+      - name: Run e2e tests for revision ${{ inputs.revision }} on ${{ matrix.lxd-image}}
         env:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
-          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
-          # Upgrading from 1.30 is not supported.
-          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_DEFAULT_WAIT_RETRIES: 30
           TEST_DEFAULT_WAIT_DELAY_S: 10
+          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          tox -e promote -- \
-            ${{ inputs.dry_run && ' --dry-run' || '' }} \
-            test \
-            --branch="${{ inputs.branch }}"
+          tox -e integration -- -k "not test_version_upgrades"
       - name: Prepare inspection reports
         if: failure()
         run: |
@@ -107,11 +154,8 @@ jobs:
   promote-proposal:
     name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
-    needs: test-proposal
+    needs: test-proposal-e2e
     steps:
-    - uses: step-security/harden-runner@v2
-      with:
-        egress-policy: audit
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -130,7 +130,7 @@ jobs:
           sg lxd -c 'lxc version'
       - name: Run e2e tests for revision ${{ inputs.revision }} on ${{ matrix.lxd-image}}
         env:
-          TEST_SNAP: ${{ inputs.revision }}
+          TEST_SNAP: "${{ inputs.revision }}"
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -130,6 +130,7 @@ jobs:
           sg lxd -c 'lxc version'
       - name: Run e2e tests for revision ${{ inputs.revision }} on ${{ matrix.lxd-image}}
         env:
+          TEST_SNAP: ${{ inputs.revision }}
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -4,108 +4,108 @@ on:
   workflow_call:
     inputs:
       branch:
-        description: 'The branch of the k8s-snap to use for testing the proposal'
+        description: "The branch of the k8s-snap to use for testing the proposal"
         required: true
         type: string
       dry_run:
-        description: 'If true, it will trigger the test, but not promote on success'
+        description: "If true, it will trigger the test, but not promote on success"
         required: false
         type: boolean
       lxd-channel:
-        description: 'The LXD channel to use for testing the proposal'
-        default: '5.21/stable'
+        description: "The LXD channel to use for testing the proposal"
+        default: "5.21/stable"
         type: string
       lxd-images:
-        description: 'The LXD images to use for testing the proposal'
+        description: "The LXD images to use for testing the proposal"
         required: true
         type: string
       proposal-name:
-        description: 'The name of the proposal to test'
+        description: "The name of the proposal to test"
         required: true
         type: string
       revision:
-        description: 'The snap revision to promote'
+        description: "The snap revision to promote"
         required: true
         type: string
       runner-labels:
-        description: 'The github runner-label for this job'
+        description: "The github runner-label for this job"
         required: true
         type: string
       snap-channel:
-        description: 'The channels to promote the snap to'
+        description: "The channels to promote the snap to"
         required: true
         type: string
       upgrade-channels:
-        description: 'The upgrade paths to test'
+        description: "The upgrade paths to test"
         required: true
         type: string
     secrets:
       SNAPSTORE_AUTH_TOKEN:
         required: true
 jobs:
-#  test-proposal-upgrades:
-#    name: ${{ join(matrix.upgrade-channel, ' to ')}} on ${{ matrix.lxd-image}}
-#    runs-on: ${{ fromJson(inputs.runner-labels) }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        # a unique runner for each lxd-image and upgrade-path
-#        lxd-image: ${{ fromJSON(inputs.lxd-images) }}
-#        upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
-#    env:
-#      ARCHITECTURE: ''
-#      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
-#    steps:
-#      - name: Update ARTIFACT_NAME
-#        run: |
-#          ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
-#          ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
-#          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
-#          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.12'
-#          cache: 'pip'
-#      - name: Install lxd and tox
-#        run: |
-#          pip install tox
-#          sudo snap install lxd --channel ${{ inputs.lxd-channel }} || true
-#          sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
-#          sudo lxd init --auto
-#          sudo usermod --append --groups lxd $USER
-#          sg lxd -c 'lxc version'
-#      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
-#        env:
-#          TEST_SUBSTRATE: lxd
-#          TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
-#          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
-#          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
-#          # Upgrading from 1.30 is not supported.
-#          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
-#          TEST_DEFAULT_WAIT_RETRIES: 30
-#          TEST_DEFAULT_WAIT_DELAY_S: 10
-#          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
-#        run: |
-#          tox -e promote -- \
-#            ${{ inputs.dry_run && ' --dry-run' || '' }} \
-#            test \
-#            --branch="${{ inputs.branch }}"
-#            --upgrade
-#      - name: Prepare inspection reports
-#        if: failure()
-#        run: |
-#          tar -czvf ${{ github.workspace }}/inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
-#      - name: Upload test results
-#        uses: actions/upload-artifact@v4
-#        if: failure()
-#        with:
-#          name: ${{ env.ARTIFACT_NAME }}
-#          path: ${{ github.workspace }}/inspection-reports.tar.gz
-#      - name: Debugging session
-#        if: ${{ failure() && github.event_name == 'pull_request' }}
-#        uses: canonical/action-tmate@main
-#        timeout-minutes: 10
+  #  test-proposal-upgrades:
+  #    name: ${{ join(matrix.upgrade-channel, ' to ')}} on ${{ matrix.lxd-image}}
+  #    runs-on: ${{ fromJson(inputs.runner-labels) }}
+  #    strategy:
+  #      fail-fast: false
+  #      matrix:
+  #        # a unique runner for each lxd-image and upgrade-path
+  #        lxd-image: ${{ fromJSON(inputs.lxd-images) }}
+  #        upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
+  #    env:
+  #      ARCHITECTURE: ''
+  #      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
+  #    steps:
+  #      - name: Update ARTIFACT_NAME
+  #        run: |
+  #          ARTIFACT_NAME=${ARTIFACT_NAME/:/-}    # replace : with -
+  #          ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
+  #          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+  #          echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
+  #      - uses: actions/checkout@v4
+  #      - uses: actions/setup-python@v5
+  #        with:
+  #          python-version: '3.12'
+  #          cache: 'pip'
+  #      - name: Install lxd and tox
+  #        run: |
+  #          pip install tox
+  #          sudo snap install lxd --channel ${{ inputs.lxd-channel }} || true
+  #          sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
+  #          sudo lxd init --auto
+  #          sudo usermod --append --groups lxd $USER
+  #          sg lxd -c 'lxc version'
+  #      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
+  #        env:
+  #          TEST_SUBSTRATE: lxd
+  #          TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
+  #          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+  #          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
+  #          # Upgrading from 1.30 is not supported.
+  #          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
+  #          TEST_DEFAULT_WAIT_RETRIES: 30
+  #          TEST_DEFAULT_WAIT_DELAY_S: 10
+  #          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
+  #        run: |
+  #          tox -e promote -- \
+  #            ${{ inputs.dry_run && ' --dry-run' || '' }} \
+  #            test \
+  #            --branch="${{ inputs.branch }}"
+  #            --upgrade
+  #      - name: Prepare inspection reports
+  #        if: failure()
+  #        run: |
+  #          tar -czvf ${{ github.workspace }}/inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+  #      - name: Upload test results
+  #        uses: actions/upload-artifact@v4
+  #        if: failure()
+  #        with:
+  #          name: ${{ env.ARTIFACT_NAME }}
+  #          path: ${{ github.workspace }}/inspection-reports.tar.gz
+  #      - name: Debugging session
+  #        if: ${{ failure() && github.event_name == 'pull_request' }}
+  #        uses: canonical/action-tmate@main
+  #        timeout-minutes: 10
   test-proposal-e2e:
     #needs: test-proposal-upgrades
     name: ${{ inputs.snap-channel }} on ${{ matrix.lxd-image}}
@@ -118,8 +118,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'pip'
+          python-version: "3.12"
+          cache: "pip"
       - name: Install lxd and tox
         run: |
           pip install tox
@@ -137,7 +137,10 @@ jobs:
           TEST_DEFAULT_WAIT_DELAY_S: 10
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          tox -e integration -- -k "not test_version_upgrades"
+          tox -e promote -- \
+            ${{ inputs.dry_run && ' --dry-run' || '' }} \
+            test \
+            --branch="${{ inputs.branch }}"
       - name: Prepare inspection reports
         if: failure()
         run: |
@@ -157,17 +160,17 @@ jobs:
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     needs: test-proposal-e2e
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-        cache: 'pip'
-    - run: pip install tox
-    - run: sudo snap install snapcraft --classic
-    - name: Promote
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}
-      run: |
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - run: pip install tox
+      - run: sudo snap install snapcraft --classic
+      - name: Promote
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}
+        run: |
           tox -e promote -- \
           ${{ inputs.dry_run && ' --dry-run' || '' }} \
           promote \

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -91,6 +91,7 @@ jobs:
 #            ${{ inputs.dry_run && ' --dry-run' || '' }} \
 #            test \
 #            --branch="${{ inputs.branch }}"
+#            --upgrade
 #      - name: Prepare inspection reports
 #        if: failure()
 #        run: |

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -107,7 +107,7 @@ jobs:
   #        uses: canonical/action-tmate@main
   #        timeout-minutes: 10
   test-proposal-e2e:
-    #needs: test-proposal-upgrades
+    # needs: test-proposal-upgrades
     name: ${{ inputs.snap-channel }} on ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -107,7 +107,7 @@ jobs:
 #        timeout-minutes: 10
   test-proposal-e2e:
     #needs: test-proposal-upgrades
-    name: ${{ matrix.snap-channel, ' to ')}} on ${{ matrix.lxd-image}}
+    name: ${{ inputs.snap-channel }} on ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
       fail-fast: true

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -357,10 +357,11 @@ def main():
     test_args.add_argument(
         "--upgrade", action="store_true", help="Only run the upgrade tests"
     )
-    if test_args.parse_known_args()[0].upgrade:
-        test_args.set_defaults(func=execute_proposal_test)
-    else:
-        test_args.set_defaults(func=execute_proposal_e2e)
+    test_args.set_defaults(
+        func=lambda args: execute_proposal_test(args)
+        if args.upgrade
+        else execute_proposal_e2e(args)
+    )
 
     promote_args = subparsers.add_parser(
         "promote", help="Promote the proposed revisions"

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -296,13 +296,13 @@ def execute_proposal_test(args):
 
 def execute_proposal_e2e(args):
     branches = {args.branch, "main"}  # branch choices
-    cmd = f"{TOX_PATH} -e integration -- -k 'not test_version_upgrades'"
+    cmd = [TOX_PATH, "-e", "integration", "--", "-k", "not test_version_upgrades"]
 
     for branch in branches:
         with repo.clone(util.SNAP_REPO, branch) as dir:
-            if repo.ls_tree(dir, "tests/integration/tests/"):
+            if repo.ls_tree(dir, "tests/integration/"):
                 LOG.info("Running integration tests for %s", branch)
-                subprocess.run(cmd.split(), cwd=dir / "tests/integration", check=True)
+                subprocess.run(cmd, cwd=dir / "tests/integration", check=True)
                 return
 
 def main():


### PR DESCRIPTION
Add a post-upgrade test step that runs the full test suite before promoting a revision.
Also, remove the test hardening runner as we don't want to rely on that job in our CI.