### PR TITLE
Fix snap recipe creation

### DIFF
--- a/scripts/ensure_snap_builds.py
+++ b/scripts/ensure_snap_builds.py
@@ -101,7 +101,7 @@ def ensure_lp_recipe(
         LOG.info(" Creating LP recipe %s", recipe_name)
         params = dict(**manifest)
         params.pop("auto_build_channels")
-        recipe = (not dry_run) and lp.snaps.new(project=lp_project, **params)
+        recipe = (not dry_run) and lp.client().snaps.new(project=lp_project, **params)
 
     if recipe:
         LOG.info(" Confirming LP recipe %s", recipe_name)

--- a/scripts/ensure_snap_builds.py
+++ b/scripts/ensure_snap_builds.py
@@ -101,7 +101,7 @@ def ensure_lp_recipe(
         LOG.info(" Creating LP recipe %s", recipe_name)
         params = dict(**manifest)
         params.pop("auto_build_channels")
-        recipe = (not dry_run) and lp.client().snaps.new(project=lp_project, **params)
+        recipe = (not dry_run) and client.snaps.new(project=lp_project, **params)
 
     if recipe:
         LOG.info(" Confirming LP recipe %s", recipe_name)


### PR DESCRIPTION
The snap recipe creation fails with:
```
Traceback (most recent call last):
  File "/home/runner/work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/scripts/ensure_snap_builds.py", line 186, in <module>
    main()
  File "/home/runner/work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/scripts/ensure_snap_builds.py", line 179, in main
    prepare_track_builds(branch, args)
  File "/home/runner/work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/scripts/ensure_snap_builds.py", line 151, in prepare_track_builds
    ensure_lp_recipe(flavour, ver, channels, tip, args.dry_run)
  File "/home/runner/work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/scripts/ensure_snap_builds.py", line 104, in ensure_lp_recipe
    recipe = (not dry_run) and lp.snaps.new(project=lp_project, **params)
```
https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/12259675509/job/34202412016