### PR TITLE
Don't fail workflow if no revision needs promotion

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -82,7 +82,7 @@ jobs:
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   test-proposal:
     if: ${{ needs.promotion-proposal.outputs.proposals && needs.promotion-proposal.outputs.proposals != '[]' }}
-    needs: promotion-required
+    needs: promotion-proposal
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:
       fail-fast: false   # Don't fail the entire matrix if one proposal fails

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -81,6 +81,7 @@ jobs:
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   test-proposal:
+    if: ${{ needs.promotion-proposal.outputs.proposals && fromJson(needs.promotion-proposal.outputs.proposals) != [] }}
     needs: promotion-proposal
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -80,14 +80,16 @@ jobs:
         id: propose-promotions
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
-  test-output:
+  promotion-required:
     runs-on: ubuntu-latest
-    needs: promotion-proposal
-    steps:
-      - run: echo "${{ needs.promotion-proposal.outputs.proposals }}"
-  test-proposal:
     if: ${{ needs.promotion-proposal.outputs.proposals && fromJson(needs.promotion-proposal.outputs.proposals) != '[]' }}
     needs: promotion-proposal
+    steps:
+      - run: |
+          echo "${{ needs.promotion-proposal.outputs.proposals }}"
+          echo "${{ fromJson(needs.promotion-proposal.outputs.proposals) }}"
+  test-proposal:
+    needs: promotion-required
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:
       fail-fast: false   # Don't fail the entire matrix if one proposal fails

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -80,15 +80,8 @@ jobs:
         id: propose-promotions
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
-  promotion-required:
-    runs-on: ubuntu-latest
-    if: ${{ needs.promotion-proposal.outputs.proposals && needs.promotion-proposal.outputs.proposals != '[]' }}
-    needs: promotion-proposal
-    steps:
-      - run: |
-          echo "${{ needs.promotion-proposal.outputs.proposals }}"
-          echo "${{ fromJson(needs.promotion-proposal.outputs.proposals) }}"
   test-proposal:
+    if: ${{ needs.promotion-proposal.outputs.proposals && needs.promotion-proposal.outputs.proposals != '[]' }}
     needs: promotion-required
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -80,6 +80,11 @@ jobs:
         id: propose-promotions
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
+  test-output:
+    runs-on: ubuntu-latest
+    needs: promotion-proposal
+    steps:
+      - run: echo "${{ needs.promotion-proposal.outputs.proposals }}"
   test-proposal:
     if: ${{ needs.promotion-proposal.outputs.proposals && fromJson(needs.promotion-proposal.outputs.proposals) != '[]' }}
     needs: promotion-proposal

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -82,7 +82,7 @@ jobs:
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   promotion-required:
     runs-on: ubuntu-latest
-    if: ${{ needs.promotion-proposal.outputs.proposals && fromJson(needs.promotion-proposal.outputs.proposals) != '[]' }}
+    if: ${{ needs.promotion-proposal.outputs.proposals && needs.promotion-proposal.outputs.proposals != '[]' }}
     needs: promotion-proposal
     steps:
       - run: |

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -81,7 +81,7 @@ jobs:
         run: |
           LPCREDS=./lp_creds tox -e promote -- propose --gh-action ${{ env.ARGS }}
   test-proposal:
-    if: ${{ needs.promotion-proposal.outputs.proposals && fromJson(needs.promotion-proposal.outputs.proposals) != [] }}
+    if: ${{ needs.promotion-proposal.outputs.proposals && fromJson(needs.promotion-proposal.outputs.proposals) != '[]' }}
     needs: promotion-proposal
     name: ${{ matrix.arch }} r${{ matrix.revision }} for ${{matrix.snap-channel}}
     strategy:


### PR DESCRIPTION
The workflow is failing in subsequent steps due to an empty matrix. See https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/12274025745/job/34246068787
