### PR TITLE
Use regexp to ignore tracks

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -73,8 +73,8 @@ jobs:
       - name: Assemble auto-promotion Arguments
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
-            # Ignore the 1.30 track for auto-promotion. We don't support it.
-            ARGS="$ARGS --ignore-tracks 1.30-moonray 1.30-classic"
+            # Ignore the 1.30 and strict tracks for auto-promotion. We don't support them.
+            ARGS="$ARGS --ignore-tracks ^1\.\d$ ^1\.30(-.*)?$"
             echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
             # Ignore the 1.30 and strict tracks for auto-promotion. We don't support them.
-            ARGS="$ARGS --ignore-tracks ^1\.\d{2}$ ^1\.30(-.*)?$"
+            ARGS="$ARGS --ignore-tracks '^1\.\d{2}$' '^1\.30(-.*)?$'"
             echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
             # Ignore the 1.30 and strict tracks for auto-promotion. We don't support them.
-            ARGS="$ARGS --ignore-tracks ^1\.\d$ ^1\.30(-.*)?$"
+            ARGS="$ARGS --ignore-tracks ^1\.\d{2}$ ^1\.30(-.*)?$"
             echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -203,9 +203,11 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             chan_log.debug("Skipping promoting stable")
             continue
 
-        if track in ignored_tracks:
-            chan_log.debug("Skipping ignored track")
+        matched_pattern = next((pattern for pattern in ignored_tracks if re.fullmatch(pattern, track)), None)
+        if matched_pattern:
+            chan_log.debug(f"Skipping ignored track '{track}' (matched pattern: '{matched_pattern}')")
             continue
+
 
         if arch in ignored_arches:
             chan_log.debug("Skipping ignored architecture")

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -203,11 +203,9 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             chan_log.debug("Skipping promoting stable")
             continue
 
-        matched_pattern = next((pattern for pattern in ignored_tracks if re.fullmatch(pattern, track)), None)
-        if matched_pattern:
-            chan_log.debug(f"Skipping ignored track '{track}' (matched pattern: '{matched_pattern}')")
+        if any(re.fullmatch(pattern, track) for pattern in ignored_tracks):
+            chan_log.debug("Skipping track because it matches ignore pattern %s", track)
             continue
-
 
         if arch in ignored_arches:
             chan_log.debug("Skipping ignored architecture")

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -199,6 +199,10 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
 
         final_channel = f"{track}/{next_risk}"
 
+        if not track:
+            chan_log.debug("Skipping trackless channel")
+            continue
+
         if not next_risk:
             chan_log.debug("Skipping promoting stable")
             continue

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -203,8 +203,9 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             chan_log.debug("Skipping promoting stable")
             continue
 
-        if any(re.fullmatch(pattern, track) for pattern in ignored_tracks):
-            chan_log.debug("Skipping track because it matches ignore pattern %s", track)
+        matched_pattern = next((pattern for pattern in ignored_tracks if re.fullmatch(pattern, track)), None)
+        if matched_pattern:
+            chan_log.debug(f"Skipping ignored track '{track}' (matched pattern: '{matched_pattern}')")
             continue
 
         if arch in ignored_arches:

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -131,19 +131,18 @@ def test_latest_track(risk, now):
     assert proposals == [], "Latest track should not be promoted"
 
 @pytest.mark.parametrize(
-    "track, ignored_patterns, expected_result",
+    "track, ignored_patterns, expected_ignored",
     [
         ("1.31", ["1\\.31", r"1\.\d+-classic"], True),  # Exact match
         ("1.31-classic", ["1\\.31", r"1\.\d+-classic"], True),  # Regex match
         ("1.32", ["1\\.31", r"1\.\d+-classic"], False),  # No match
-        ("2.0-alpha", ["2\\.0.*"], True),  # Regex match for 2.0-alpha
-        ("latest", ["1\\.31", r"1\.\d+-classic"], False),  # No match
+        ("1.31-classic", [], False),  # Nothing ignored
     ],
 )
-def test_ignored_tracks(track, ignored_patterns, expected_result):
-    with mock.patch("promote_tracks.ignored_tracks", ignored_patterns):
-        with _make_channel_map(track, "edge"):
-            proposals = promote_tracks.create_proposal(args)
-        assert (len(proposals) == 0) == expected_result, (
-            f"Track '{track}' should {'be ignored' if expected_result else 'not be ignored'}"
+def test_ignored_tracks(track, ignored_patterns, expected_ignored):
+    with _make_channel_map(track, "edge"):
+        args.ignored_tracks = ignored_patterns
+        proposals = promote_tracks.create_proposal(args)
+    assert (len(proposals) == 0) == expected_ignored, (
+        f"Track '{track}' should {'be ignored' if expected_ignored else 'not be ignored'}"
         )

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -133,7 +133,7 @@ def test_latest_track(risk, now):
 @pytest.mark.parametrize(
     "track, ignored_patterns, expected_ignored",
     [
-        ("1.31", ["1\\.31", r"1\.\d+-classic"], True),  # Exact match
+        ("1.31", ["1.31", r"1\.\d+-classic"], True),  # Exact match
         ("1.31-classic", ["1\\.31", r"1\.\d+-classic"], True),  # Regex match
         ("1.32", ["1\\.31", r"1\.\d+-classic"], False),  # No match
         ("1.31-classic", [], False),  # Nothing ignored
@@ -141,7 +141,7 @@ def test_latest_track(risk, now):
 )
 def test_ignored_tracks(track, ignored_patterns, expected_ignored):
     with _make_channel_map(track, "edge"):
-        args.ignored_tracks = ignored_patterns
+        args.ignore_tracks = ignored_patterns
         proposals = promote_tracks.create_proposal(args)
     assert (len(proposals) == 0) == expected_ignored, (
         f"Track '{track}' should {'be ignored' if expected_ignored else 'not be ignored'}"


### PR DESCRIPTION
We don't support 1.30 and the strict version of the snap (right now), which makes it unnecessary to run the promotion/upgrade tests for those versions.

Updated the `ignored_tracks` parameter to support regexp to support strict channel.