### PR TITLE
Increase test timeouts

### DIFF
--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -83,7 +83,7 @@ jobs:
           TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
-          TEST_DEFAULT_WAIT_RETRIES: 30
+          TEST_DEFAULT_WAIT_RETRIES: 200
           TEST_DEFAULT_WAIT_DELAY_S: 10
         run: |
           tox -e promote -- \


### PR DESCRIPTION
The upgrate tests time out while waiting for the cilium image
to be downloaded.

Note that we have a large amount of parallel tests (~100) that
do not share the same env and cannot benefit from the image
proxy, leading to a large number of image downloads.

For now, we'll increase the test timeouts.