### PR TITLE
Lpetrut/quick promotion

### DIFF
--- a/scripts/ensure_snap_builds.py
+++ b/scripts/ensure_snap_builds.py
@@ -58,9 +58,7 @@ def ensure_lp_recipe(
         # Use a single branch for all pre-releases of a given risk level,
         # e.g. v1.33.0-alpha.0 -> autoupdate/v1.33.0-alpha
         prerelease = ver.prerelease.split(".")[0]
-        flavor_branch = (
-            f"autoupdate/v{ver.major}.{ver.minor}.{ver.patch}-{prerelease}"
-        )
+        flavor_branch = f"autoupdate/v{ver.major}.{ver.minor}.{ver.patch}-{prerelease}"
     elif tip:
         flavor_branch = "main" if flavour == "classic" else f"autoupdate/{flavour}"
     elif flavour == "classic":

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -14,6 +14,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
+import k8s_release
 import util.gh as gh
 import util.lp as lp
 import util.repo as repo
@@ -134,7 +135,7 @@ def _build_upgrade_channels(
         maj, min, tail = match.groups()
     else:
         raise ValueError(f"Invalid track name: {track}")
-    prior_track = f"{maj}.{int(min)-1}{tail}"
+    prior_track = f"{maj}.{int(min) - 1}{tail}"
     prior_track_channels = [f"{prior_track}/{r}" for r in RISK_LEVELS]
     for source in reversed(prior_track_channels):
         if source in channels:
@@ -190,6 +191,7 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
     def sorter(info: Channel):
         return (info.name, RISK_LEVELS.index(info.risk))
 
+    latest_upstream_stable = k8s_release.get_latest_stable()
     for channel_info in sorted(channels.values(), key=sorter, reverse=True):
         track = channel_info.channel.track
         risk = channel_info.risk
@@ -247,38 +249,54 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             != channels.get(f"{track}/{risk}", EMPTY_CHANNEL).version
         )
 
-        if purgatory_complete or new_patch_in_edge:
-            if next_risk == "stable" and f"{track}/stable" not in channels.keys():
-                # The track has not yet a stable release.
-                # The first stable release requires blessing from SolQA and needs to be promoted manually.
-                # Follow-up patches do not require this.
-                chan_log.warning(
-                    "Approval rev=%-5s arch=%s to %s needed by SolQA",
-                    revision,
-                    arch,
-                    next_risk,
-                )
-            else:
+        def _get_proposal():
+            proposal = {}
+            proposal["arch"] = arch
+            proposal["branch"] = lp.branch_from_track(util.SNAP_NAME, track)
+            proposal["upgrade-channels"] = _build_upgrade_channels(
+                channel_info, channels
+            )
+            proposal["revision"] = revision
+            proposal["track"] = track
+            proposal["next-risk"] = next_risk
+            proposal["snap-channel"] = final_channel
+            proposal["name"] = f"{util.SNAP_NAME}-{track}/{next_risk}-{arch}"
+            proposal["runner-labels"] = gh.arch_to_gh_labels(arch, self_hosted=True)
+            proposal["lxd-images"] = [f"ubuntu:{series}" for series in SERIES]
+            return proposal
+
+        # Whenever there's a new stable upstream release, we'll skip purgatory
+        # and promote it to all risk levels, including stable.
+        # Out of caution, we'll only do this for the latest upstream release
+        # and channels that do not have a beta release yet.
+        if risk == "edge" and f"{track}/beta" not in channels.keys():
+            bom = util.get_k8s_snap_bom((channel_info.download or {}).get("url"))
+            k8s_version = bom["components"]["kubernetes"]["version"]
+            if k8s_version == latest_upstream_stable:
                 chan_log.info(
-                    "Promotes rev=%-5s arch=%s to %s",
-                    revision,
-                    arch,
-                    next_risk,
+                    f"{track}/edge contains a stable upstream release: {k8s_version}, "
+                    "we'll skip purgatory and promote it to all risk levels "
+                    "(including stable)."
                 )
-                proposal = {}
-                proposal["arch"] = arch
-                proposal["branch"] = lp.branch_from_track(util.SNAP_NAME, track)
-                proposal["upgrade-channels"] = _build_upgrade_channels(
-                    channel_info, channels
-                )
-                proposal["revision"] = revision
-                proposal["track"] = track
-                proposal["next-risk"] = next_risk
-                proposal["snap-channel"] = final_channel
-                proposal["name"] = f"{util.SNAP_NAME}-{track}/{next_risk}-{arch}"
-                proposal["runner-labels"] = gh.arch_to_gh_labels(arch, self_hosted=True)
-                proposal["lxd-images"] = [f"ubuntu:{series}" for series in SERIES]
-                proposals.append(proposal)
+                for proposed_risk in ("beta", "candidate", "stable"):
+                    chan_log.info(
+                        "Promotes rev=%-5s arch=%s to %s",
+                        revision,
+                        arch,
+                        proposed_risk,
+                    )
+                    proposal = _get_proposal()
+                    proposal["next-risk"] = proposed_risk
+                    proposals.append(proposal)
+        elif purgatory_complete or new_patch_in_edge:
+            chan_log.info(
+                "Promotes rev=%-5s arch=%s to %s",
+                revision,
+                arch,
+                next_risk,
+            )
+            proposal = _get_proposal()
+            proposals.append(proposal)
     return proposals
 
 

--- a/scripts/util/lp.py
+++ b/scripts/util/lp.py
@@ -12,6 +12,7 @@ def client():
     """Use launchpad credentials to interact with launchpad."""
     cred_file = os.getenv("LPCREDS")
     creds_local = os.getenv("LPLOCAL")
+    anon_login = os.getenv("LPANON", "").lower() in ("1", "true")
     if cred_file:
         parser = ConfigParser()
         parser.read(cred_file)
@@ -26,6 +27,11 @@ def client():
             "localhost",
             "production",
             version="devel",
+        )
+    elif anon_login:
+        # Anonymous login, can be used for dry-runs.
+        return Launchpad.login_anonymously(
+            "Canonical K8s promotion dry-run", "production", version="devel"
         )
     else:
         raise ValueError("No launchpad credentials found")

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -116,9 +116,9 @@ def test_risk_promotable_without_stable(risk, now):
     with freeze_time(now), _make_channel_map(MOCK_TRACK, risk):
         proposals = promote_tracks.create_proposal(args)
 
-    assert (
-        proposals == []
-    ), "Candidate track should not be promoted if stable is missing"
+    assert proposals == [], (
+        "Candidate track should not be promoted if stable is missing"
+    )
 
 
 @pytest.mark.parametrize(
@@ -144,6 +144,6 @@ def test_ignored_tracks(track, ignored_patterns, expected_ignored):
     with _make_channel_map(track, "edge"):
         args.ignore_tracks = ignored_patterns
         proposals = promote_tracks.create_proposal(args)
-    assert (
-        (len(proposals) == 0) == expected_ignored
-    ), f"Track '{track}' should {'be ignored' if expected_ignored else 'not be ignored'}"
+    assert (len(proposals) == 0) == expected_ignored, (
+        f"Track '{track}' should {'be ignored' if expected_ignored else 'not be ignored'}"
+    )


### PR DESCRIPTION
Directly promote snaps containing stable upstream releases

Whenever there's a new stable upstream release, we'll skip purgatory and promote it to all risk levels, including stable.

We'll only do this for the latest upstream release and channels that do not have a beta release yet.