### PR TITLE
Avoid pulling snaps to detect version

### DIFF
--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -273,9 +273,7 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
         # We'll only do this for the latest upstream release
         # and channels that do not have a stable release yet.
         if not revision_in_stable:
-            k8s_version = util.get_k8s_snap_version(
-                (channel_info.download or {}).get("url")
-            )
+            k8s_version = channel_info.version
 
             if new_patch_in_edge and k8s_version == latest_upstream_stable:
                 chan_log.info(

--- a/scripts/util/util.py
+++ b/scripts/util/util.py
@@ -1,15 +1,10 @@
 import argparse
-import json
 import logging
-import os
 import re
-import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import List
 
-import requests
 import semver
 import util.repo as repo
 
@@ -60,34 +55,6 @@ def setup_arguments(arg_parser: argparse.ArgumentParser):
     args = arg_parser.parse_args()
     setup_logging(args)
     return args
-
-
-def download_file(url: str, dest: str, timeout: int = 10):
-    with requests.get(url, stream=True, timeout=timeout) as r:
-        with open(dest, "wb") as f:
-            shutil.copyfileobj(r.raw, f)
-
-
-def get_k8s_snap_bom(url: str):
-    tmpdir = tempfile.mkdtemp()
-    try:
-        snap_path = os.path.join(tmpdir, "k8s.snap")
-        download_file(url, snap_path)
-        execute(
-            ["unsquashfs", "-q", "-n", snap_path, "-extract-file", "bom.json"],
-            cwd=tmpdir,
-        )
-        bom_path = os.path.join(tmpdir, "squashfs-root", "bom.json")
-        with open(bom_path, "r") as f:
-            return json.load(f)
-    finally:
-        shutil.rmtree(tmpdir)
-
-
-def get_k8s_snap_version(url: str) -> str:
-    """Retrieve the Kubernetes component version for a given snap download url."""
-    bom = get_k8s_snap_bom(url)
-    return bom["components"]["kubernetes"]["version"]
 
 
 def execute(cmd: List[str], check=True, timeout=EXEC_TIMEOUT, cwd=None):

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -78,13 +78,10 @@ def _make_channel_map(track: str, risk: str, extra_risk: None | str = None):
 
 
 @contextlib.contextmanager
-def _mock_k8s_versions(latest_stable: str = "1.33.0", snap_release: str = "1.32.0"):
+def _mock_k8s_versions(latest_stable: str = "v1.33.0"):
     with (
         mock.patch(
             "k8s_release.get_latest_stable", new=mock.Mock(return_value=latest_stable)
-        ),
-        mock.patch(
-            "util.util.get_k8s_snap_version", new=mock.Mock(return_value=snap_release)
         ),
     ):
         yield
@@ -161,7 +158,8 @@ def test_ignored_tracks(track, ignored_patterns, expected_ignored):
 
 
 def test_new_stable():
-    with _make_channel_map(MOCK_TRACK, "edge"), _mock_k8s_versions("1.31.5", "1.31.5"):
+    # In this scenario, the channel version matches the latest stable.
+    with _make_channel_map(MOCK_TRACK, "edge"), _mock_k8s_versions("v1.31.0"):
         proposals = promote_tracks.create_proposal(args)
 
     # New stable release, we expect it to be promoted to all risk levels.


### PR DESCRIPTION
Looks like the snap info already contains the packaged k8s version, so we don't actually have to download the snaps and unsquash them.