### PR TITLE
Create missing snap tracks if necessary

### DIFF
--- a/scripts/util/snapstore.py
+++ b/scripts/util/snapstore.py
@@ -1,8 +1,9 @@
 import base64
 import json
 import logging
-import requests
 import os
+
+import requests
 
 LOG = logging.getLogger(__name__)
 INFO_URL = "https://api.snapcraft.io/v2/snaps/info/"
@@ -23,11 +24,12 @@ def info(snap_name):
 
 def track_exists(snap_name: str, track_name: str):
     snap_info = info(snap_name)
-    for channel_data in snap_info['channel-map']:
-        track = channel_data['channel']['track']
+    for channel_data in snap_info["channel-map"]:
+        track = channel_data["channel"]["track"]
         if track == track_name:
             return True
     return False
+
 
 def ensure_track(snap_name: str, track_name: str):
     LOG.info("Ensuring track: %s %s", snap_name, track_name)
@@ -35,6 +37,7 @@ def ensure_track(snap_name: str, track_name: str):
         create_track(snap_name, track_name)
     else:
         LOG.info("Track already exists: %s %s", snap_name, track_name)
+
 
 def create_track(snap_name: str, track_name: str):
     LOG.info("Creating track: %s %s", snap_name, track_name)
@@ -61,4 +64,4 @@ def get_charmhub_auth_macaroon() -> str:
 
     str_data = base64.b64decode(creds_export_data).decode()
     auth = json.loads(str(str_data))
-    return auth['v']
+    return auth["v"]

--- a/scripts/util/snapstore.py
+++ b/scripts/util/snapstore.py
@@ -1,7 +1,8 @@
+import base64
 import json
 import logging
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+import requests
+import os
 
 LOG = logging.getLogger(__name__)
 INFO_URL = "https://api.snapcraft.io/v2/snaps/info/"
@@ -11,20 +12,53 @@ HEADERS = {
     "Snap-Device-Series": "16",
     "User-Agent": "Mozilla/5.0",
 }
+TIMEOUT = 10
 
 
 def info(snap_name):
-    req = Request(INFO_URL + snap_name, headers=HEADERS)
-    try:
-        with urlopen(req) as response:  # nosec
-            return json.loads(response.read().decode())
-    except HTTPError as e:
-        LOG.exception("HTTPError ({%s}): {%s} {%s}", req.full_url, e.code, e.reason)
-        raise
-    except URLError as e:
-        LOG.exception("URLError ({%s}): {%s}", req.full_url, e.reason)
-        raise
+    r = requests.get(INFO_URL + snap_name, headers=HEADERS, timeout=TIMEOUT)
+    r.raise_for_status()
+    return json.loads(r.text)
 
+
+def track_exists(snap_name: str, track_name: str):
+    snap_info = info(snap_name)
+    for channel_data in snap_info['channel-map']:
+        track = channel_data['channel']['track']
+        if track == track_name:
+            return True
+    return False
 
 def ensure_track(snap_name: str, track_name: str):
-    pass
+    LOG.info("Ensuring track: %s %s", snap_name, track_name)
+    if not track_exists(snap_name, track_name):
+        create_track(snap_name, track_name)
+    else:
+        LOG.info("Track already exists: %s %s", snap_name, track_name)
+
+def create_track(snap_name: str, track_name: str):
+    LOG.info("Creating track: %s %s", snap_name, track_name)
+
+    # Yes, the snap creation API is really at charmhub.io.
+    # See https://juju.is/docs/sdk/create-a-track-for-your-charm#heading--self-service
+    # For obvious reasons, we will keep this function in the snapstore module regardless.
+    url = f"https://api.charmhub.io/v1/snap/{snap_name}/tracks"
+    auth_macaroon = get_charmhub_auth_macaroon()
+    headers = {
+        "Authorization": f"Macaroon {auth_macaroon}",
+        "Content-Type": "application/json",
+    }
+    data = [{"name": track_name}]
+    r = requests.post(url, headers=headers, json=data, timeout=TIMEOUT)
+    r.raise_for_status()
+
+
+def get_charmhub_auth_macaroon() -> str:
+    # Auth credentials provided by "charmcraft login --export $outfile"
+    creds_export_data = os.getenv("CHARMCRAFT_AUTH")
+    if not creds_export_data:
+        raise ValueError("Missing charmhub credentials,")
+
+    str_data = base64.b64decode(creds_export_data).decode()
+    auth = json.loads(str(str_data))
+    return auth['v']

--- a/scripts/util/snapstore.py
+++ b/scripts/util/snapstore.py
@@ -13,6 +13,7 @@ HEADERS = {
     "Snap-Device-Series": "16",
     "User-Agent": "Mozilla/5.0",
 }
+# Timeout for Store API request in seconds
 TIMEOUT = 10
 
 

--- a/scripts/util/snapstore.py
+++ b/scripts/util/snapstore.py
@@ -22,16 +22,18 @@ def info(snap_name):
     return json.loads(r.text)
 
 
-def track_exists(snap_name: str, track_name: str):
+def track_exists(snap_name: str, track_name: str) -> bool:
+    """Check if a track exists for a snap."""
     snap_info = info(snap_name)
-    for channel_data in snap_info["channel-map"]:
-        track = channel_data["channel"]["track"]
-        if track == track_name:
+    for channel_data in snap_info.get("channel-map", {}):
+        track = channel_data.get("channel", {}).get("track")
+        if track and track == track_name:
             return True
     return False
 
 
-def ensure_track(snap_name: str, track_name: str):
+def ensure_track(snap_name: str, track_name: str) -> None:
+    """Ensure a track exists for a snap. If it does not exist, create it."""
     LOG.info("Ensuring track: %s %s", snap_name, track_name)
     if not track_exists(snap_name, track_name):
         create_track(snap_name, track_name)
@@ -39,7 +41,8 @@ def ensure_track(snap_name: str, track_name: str):
         LOG.info("Track already exists: %s %s", snap_name, track_name)
 
 
-def create_track(snap_name: str, track_name: str):
+def create_track(snap_name: str, track_name: str) -> None:
+    """Create a track for a snap. Throws an exception if the track already exists."""
     LOG.info("Creating track: %s %s", snap_name, track_name)
 
     # Yes, the snap creation API is really at charmhub.io.
@@ -57,6 +60,11 @@ def create_track(snap_name: str, track_name: str):
 
 
 def get_charmhub_auth_macaroon() -> str:
+    """Get the charmhub macaroon from the environment.
+
+    This is used to authenticate with the charmhub API.
+    Will raise a ValueError if CHARMCRAFT_AUTH is not set or the credentials are malformed.
+    """
     # Auth credentials provided by "charmcraft login --export $outfile"
     creds_export_data = os.getenv("CHARMCRAFT_AUTH")
     if not creds_export_data:
@@ -64,4 +72,7 @@ def get_charmhub_auth_macaroon() -> str:
 
     str_data = base64.b64decode(creds_export_data).decode()
     auth = json.loads(str(str_data))
-    return auth["v"]
+    v = auth.get("v")
+    if not v:
+        raise ValueError("Malformed charmhub credentials")
+    return v

--- a/tests/unit/util/test_snapstore.py
+++ b/tests/unit/util/test_snapstore.py
@@ -1,46 +1,84 @@
 import json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from urllib.error import HTTPError, URLError
-
 import pytest
 import util.snapstore as snapstore
 
-
-@patch("util.snapstore.urlopen")
-def test_info_success(mock_urlopen):
-    # Mock the response from urlopen
-    context = mock_urlopen.return_value.__enter__.return_value
-    context.read.return_value = json.dumps({"name": "test-snap"}).encode("utf-8")
+@patch("util.snapstore.requests.get")
+def test_info_success(mock_get):
+    # Mock the response from requests.get
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = json.dumps({"name": "test-snap"})
+    mock_get.return_value = mock_response
 
     result = snapstore.info("test-snap")
     assert result == {"name": "test-snap"}
-    mock_urlopen.assert_called_once()
-
-
-@patch("util.snapstore.urlopen")
-def test_info_http_error(mock_urlopen):
-    # Mock an HTTPError
-    mock_urlopen.side_effect = HTTPError(
-        url="http://test-url",
-        code=404,
-        msg="Not Found",
-        hdrs=None,  # type: ignore
-        fp=None,
+    mock_get.assert_called_once_with(
+        "https://api.snapcraft.io/v2/snaps/info/test-snap",
+        headers=snapstore.HEADERS,
+        timeout=snapstore.TIMEOUT,
     )
 
-    with pytest.raises(HTTPError):
+@patch("util.snapstore.requests.get")
+def test_info_http_error(mock_get):
+    # Mock an HTTPError
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.HTTPError("Not Found")
+    mock_get.return_value = mock_response
+
+    with pytest.raises(requests.HTTPError):
         snapstore.info("non-existent-snap")
 
+@patch("util.snapstore.requests.get")
+def test_info_url_error(mock_get):
+    # Mock a ConnectionError (similar to URLError in urllib)
+    mock_get.side_effect = requests.ConnectionError("Failed to connect")
 
-@patch("util.snapstore.urlopen")
-def test_info_url_error(mock_urlopen):
-    # Mock a URLError
-    mock_urlopen.side_effect = URLError("Reason")
-
-    with pytest.raises(URLError):
+    with pytest.raises(requests.ConnectionError):
         snapstore.info("non-existent-snap")
 
-
-def test_ensure_track():
-    # Placeholder for ensure_track tests
+@patch("util.snapstore.track_exists", return_value=True)
+@patch("util.snapstore.create_track")
+def test_ensure_track_exists(mock_create_track, mock_track_exists):
     snapstore.ensure_track("test-snap", "test-track")
+    mock_track_exists.assert_called_once_with("test-snap", "test-track")
+    mock_create_track.assert_not_called()
+
+@patch("util.snapstore.track_exists", return_value=False)
+@patch("util.snapstore.create_track")
+def test_ensure_track_create(mock_create_track, mock_track_exists):
+    snapstore.ensure_track("test-snap", "test-track")
+    mock_track_exists.assert_called_once_with("test-snap", "test-track")
+    mock_create_track.assert_called_once_with("test-snap", "test-track")
+
+@patch("util.snapstore.requests.post")
+@patch("util.snapstore.get_charmhub_auth_macaroon", return_value="mock-macaroon")
+def test_create_track(mock_get_auth, mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_post.return_value = mock_response
+
+    snapstore.create_track("test-snap", "test-track")
+
+    mock_get_auth.assert_called_once()
+    mock_post.assert_called_once_with(
+        "https://api.charmhub.io/v1/snap/test-snap/tracks",
+        headers={
+            "Authorization": "Macaroon mock-macaroon",
+            "Content-Type": "application/json",
+        },
+        json=[{"name": "test-track"}],
+        timeout=snapstore.TIMEOUT,
+    )
+
+@patch("util.snapstore.os.getenv", return_value=base64.b64encode(b'{"v": "mock-macaroon"}').decode())
+def test_get_charmhub_auth_macaroon(mock_getenv):
+    result = snapstore.get_charmhub_auth_macaroon()
+    assert result == "mock-macaroon"
+    mock_getenv.assert_called_once_with("CHARMCRAFT_AUTH")
+
+@patch("util.snapstore.os.getenv", return_value=None)
+def test_get_charmhub_auth_macaroon_missing(mock_getenv):
+    with pytest.raises(ValueError, match="Missing charmhub credentials"):
+        snapstore.get_charmhub_auth_macaroon()

--- a/tests/unit/util/test_snapstore.py
+++ b/tests/unit/util/test_snapstore.py
@@ -1,8 +1,11 @@
+import base64
 import json
-from unittest.mock import patch, MagicMock
-from urllib.error import HTTPError, URLError
+from unittest.mock import MagicMock, patch
+
 import pytest
+import requests
 import util.snapstore as snapstore
+
 
 @patch("util.snapstore.requests.get")
 def test_info_success(mock_get):
@@ -20,6 +23,7 @@ def test_info_success(mock_get):
         timeout=snapstore.TIMEOUT,
     )
 
+
 @patch("util.snapstore.requests.get")
 def test_info_http_error(mock_get):
     # Mock an HTTPError
@@ -30,6 +34,7 @@ def test_info_http_error(mock_get):
     with pytest.raises(requests.HTTPError):
         snapstore.info("non-existent-snap")
 
+
 @patch("util.snapstore.requests.get")
 def test_info_url_error(mock_get):
     # Mock a ConnectionError (similar to URLError in urllib)
@@ -38,6 +43,7 @@ def test_info_url_error(mock_get):
     with pytest.raises(requests.ConnectionError):
         snapstore.info("non-existent-snap")
 
+
 @patch("util.snapstore.track_exists", return_value=True)
 @patch("util.snapstore.create_track")
 def test_ensure_track_exists(mock_create_track, mock_track_exists):
@@ -45,12 +51,14 @@ def test_ensure_track_exists(mock_create_track, mock_track_exists):
     mock_track_exists.assert_called_once_with("test-snap", "test-track")
     mock_create_track.assert_not_called()
 
+
 @patch("util.snapstore.track_exists", return_value=False)
 @patch("util.snapstore.create_track")
 def test_ensure_track_create(mock_create_track, mock_track_exists):
     snapstore.ensure_track("test-snap", "test-track")
     mock_track_exists.assert_called_once_with("test-snap", "test-track")
     mock_create_track.assert_called_once_with("test-snap", "test-track")
+
 
 @patch("util.snapstore.requests.post")
 @patch("util.snapstore.get_charmhub_auth_macaroon", return_value="mock-macaroon")
@@ -72,11 +80,16 @@ def test_create_track(mock_get_auth, mock_post):
         timeout=snapstore.TIMEOUT,
     )
 
-@patch("util.snapstore.os.getenv", return_value=base64.b64encode(b'{"v": "mock-macaroon"}').decode())
+
+@patch(
+    "util.snapstore.os.getenv",
+    return_value=base64.b64encode(b'{"v": "mock-macaroon"}').decode(),
+)
 def test_get_charmhub_auth_macaroon(mock_getenv):
     result = snapstore.get_charmhub_auth_macaroon()
     assert result == "mock-macaroon"
     mock_getenv.assert_called_once_with("CHARMCRAFT_AUTH")
+
 
 @patch("util.snapstore.os.getenv", return_value=None)
 def test_get_charmhub_auth_macaroon_missing(mock_getenv):


### PR DESCRIPTION
This commit ensures the creation of snap tracks for a release if they do not already exist. It interacts directly with the charmhub.io API (not snapstore.io) to create any missing tracks. Only new tracks that conform to the naming guard-rails (1.XX[-classic|strict|moonray]) will be automatically created.

Highly inspired by: https://github.com/canonical/canonical-kubernetes-release-ci/pull/22