### PR TITLE
Run integration tests from the release branch only

### DIFF
--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -322,15 +322,13 @@ def release_revision(args):
 
 
 def execute_proposal_test(args):
-    branches = {args.branch, "main"}  # branch choices
     cmd = f"{TOX_PATH} -e integration -- -k test_version_upgrades"
 
-    for branch in branches:
-        with repo.clone(util.SNAP_REPO, branch) as dir:
-            if repo.ls_tree(dir, "tests/integration/tests/test_version_upgrades.py"):
-                LOG.info("Running integration tests for %s", branch)
-                subprocess.run(cmd.split(), cwd=dir / "tests/integration", check=True)
-                return
+    with repo.clone(util.SNAP_REPO, args.branch) as dir:
+        if repo.ls_tree(dir, "tests/integration/tests/test_version_upgrades.py"):
+            LOG.info("Running integration tests for %s", args.branch)
+            subprocess.run(cmd.split(), cwd=dir / "tests/integration", check=True)
+            return
 
 
 def main():


### PR DESCRIPTION
The nightly promotion job is very inconsistent about which `test_version_upgrades.py` it runs and it could be linked to these choices of which branches run the promotion:


in some instances i see:

```
  tox -e promote -- \
     \
    test \
    --branch="release-1.32"
```

lead to:


```
           util.repo 2025-04-15 14:19:01,759     INFO - Cloning https://github.com/canonical/k8s-snap.git/ @ main (shallow=True)
Cloning into '/tmp/tmpeup1vhe5'...
      promote_tracks 2025-04-15 14:19:03,278     INFO - Running integration tests for main
```

and others:

```
           util.repo 2025-04-15 00:08:18,054     INFO - Cloning https://github.com/canonical/k8s-snap.git/ @ release-1.32 (shallow=True)
Cloning into '/tmp/tmpbhte762t'...
      promote_tracks 2025-04-15 00:08:19,505     INFO - Running integration tests for release-1.32
```

The ones from `main` consistently fail, and re-running the CI it might pass when the correct branch is used.  This is clearly the issue