### PR TITLE
feat: Support multiple pre-releases

### DIFF
--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -14,11 +14,10 @@ permissions:
 
 jobs:
   determine:
-    name: "Determine k8s pre-release"
+    name: "Determine k8s pre-releases"
     runs-on: ubuntu-latest
     outputs:
-      preRelease: ${{ steps.determine.outputs.preRelease }}
-      gitBranch: ${{ steps.determine.outputs.gitBranch }}
+      gitBranches: ${{ steps.determine.outputs.gitBranches }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,27 +32,23 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - name: Install Python dependencies
-        shell: bash
-        run: pip3 install -r ./scripts/requirements.txt
-      - name: Determine outstanding pre-release
+      - run: pip install tox
+      - name: Determine outstanding pre-releases
         id: determine
         run: |
-          preRelease=`python3 ./scripts/k8s_release.py get_outstanding_prerelease`
-          echo "preRelease=$preRelease" >> "$GITHUB_OUTPUT"
-
-          if [[ -n "$preRelease" ]]; then
-            gitBranch=`python3 ./scripts/k8s_release.py get_prerelease_git_branch --prerelease $preRelease`
-          fi
-          echo "gitBranch=$gitBranch" >> "$GITHUB_OUTPUT"
-  handle-pre-release:
-    name: Handle pre-release ${{ needs.determine.outputs.preRelease }}
+          gitBranches=`tox -qq -e release -- get_outstanding_prereleases --as-git-branch`
+          echo "gitBranches=$gitBranches" >> "$GITHUB_OUTPUT"
+  handle-pre-releases:
+    name: Handle pre-releases
     needs: [determine]
-    secrets: inherit
+    if: ${{ needs.determine.outputs.preReleases != '' }}
+    strategy:
+      matrix:
+        branch: ${{ fromJson('["' + join('","', split(needs.determine.outputs.gitBranches, '\n')) + '"]') }}
     uses: ./.github/workflows/create-release-branch.yaml
-    if: ${{ needs.determine.outputs.preRelease }} != ''
+    secrets: inherit
     with:
-      branches: ${{ needs.determine.outputs.gitBranch }}
+      branches: ${{ matrix.branch }}
   clean-obsolete:
     runs-on: ubuntu-latest
     env:

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -14,8 +14,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
-import k8s_release
 import util.gh as gh
+import util.k8s as k8s
 import util.lp as lp
 import util.repo as repo
 import util.snapstore as snapstore
@@ -191,7 +191,7 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
     def sorter(info: Channel):
         return (info.name, RISK_LEVELS.index(info.risk))
 
-    latest_upstream_stable = k8s_release.get_latest_stable()
+    latest_upstream_stable = k8s.get_latest_stable()
     for channel_info in sorted(channels.values(), key=sorter, reverse=True):
         track = channel_info.channel.track
         risk = channel_info.risk
@@ -292,7 +292,7 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
                     proposals.append(proposal)
                 continue
 
-            if not k8s_release.is_stable_release(k8s_version):
+            if not k8s.is_stable_release(k8s_version):
                 chan_log.info(
                     f"{track}/{risk} contains pre-release: {k8s_version}, "
                     "automatic promotion disabled."

--- a/scripts/publish_k8s_debs.py
+++ b/scripts/publish_k8s_debs.py
@@ -17,6 +17,7 @@ from util.util import execute, setup_arguments
 
 LOG = logging.getLogger(__name__)
 
+
 def _get_ubuntu_codename() -> str:
     """Get the Ubuntu codename from /etc/os-release."""
     os_release_path = Path("/etc/os-release")
@@ -375,7 +376,7 @@ class K8sDebManager:
 
 def main():
     arg_parser = argparse.ArgumentParser(
-        Path(__file__).name, 
+        Path(__file__).name,
         description="Build and publish Debian package for a Kubernetes component.",
     )
     arg_parser.add_argument("component", help="Component name, e.g., kubeadm")

--- a/scripts/util/k8s.py
+++ b/scripts/util/k8s.py
@@ -1,0 +1,82 @@
+import json
+import re
+from typing import Dict, List
+
+import requests
+from packaging.version import Version
+
+K8S_TAGS_URL = "https://api.github.com/repos/kubernetes/kubernetes/tags"
+
+
+def _url_get(url: str) -> str:
+    """Make a GET request to the given URL and return the response text."""
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
+    return response.text
+
+
+def is_stable_release(release: str) -> bool:
+    """Check if a Kubernetes release tag is stable (no pre-release suffix).
+
+    Args:
+        release: A Kubernetes release tag (e.g. 'v1.30.1', 'v1.30.0-alpha.1').
+
+    Returns:
+        True if the release is stable, False otherwise.
+    """
+    return "-" not in release
+
+
+def get_k8s_tags() -> List[str]:
+    """Retrieve semantically ordered Kubernetes release tags from GitHub.
+
+    Returns:
+        A list of release tag strings sorted from newest to oldest.
+
+    Raises:
+        ValueError: If no tags are retrieved.
+    """
+    response = _url_get(K8S_TAGS_URL)
+    tags_json = json.loads(response)
+    if not tags_json:
+        raise ValueError("No k8s tags retrieved.")
+    tag_names = [tag["name"] for tag in tags_json]
+    tag_names.sort(key=lambda x: Version(x), reverse=True)
+    return tag_names
+
+
+def get_latest_stable() -> str:
+    """Get the latest stable Kubernetes release tag.
+
+    Returns:
+        The latest stable release tag string (e.g., 'v1.30.1').
+
+    Raises:
+        ValueError: If no stable release is found.
+    """
+    for tag in get_k8s_tags():
+        if is_stable_release(tag):
+            return tag
+    raise ValueError("Couldn't find a stable release.")
+
+
+def get_latest_releases_by_minor() -> Dict[str, str]:
+    """Map each minor Kubernetes version to its latest release tag.
+
+    Returns:
+        A dictionary mapping minor versions (e.g. '1.30') to the
+        latest (pre-)release tag (e.g. 'v1.30.1').
+    """
+    latest_by_minor: Dict[str, str] = {}
+    version_regex = re.compile(r"^v?(\d+)\.(\d+)\..+")
+
+    for tag in get_k8s_tags():
+        match = version_regex.match(tag)
+        if not match:
+            continue
+        major, minor = match.groups()
+        key = f"{major}.{minor}"
+        if key not in latest_by_minor:
+            latest_by_minor[key] = tag
+
+    return latest_by_minor

--- a/tests/unit/test_k8s_release.py
+++ b/tests/unit/test_k8s_release.py
@@ -1,0 +1,90 @@
+# test_prerelease_tool.py
+
+from unittest.mock import patch
+
+import pytest
+
+import scripts.k8s_release as k8s_release
+
+
+@patch("util.k8s.get_latest_releases_by_minor")
+def test_get_outstanding_prereleases(mock_latest):
+    mock_latest.return_value = {
+        "1.31": "v1.31.6",
+        "1.32": "v1.32.0-rc.0",
+        "1.33": "v1.33.0-alpha.0",
+    }
+
+    result = k8s_release.get_outstanding_prereleases()
+    assert result == ["v1.32.0-rc.0", "v1.33.0-alpha.0"]
+
+
+@patch("util.k8s.get_k8s_tags")
+def test_get_obsolete_prereleases_single_valid_prerelease(mock_tags):
+    # Simulate a leading pre-release followed by stable and more tags
+    mock_tags.return_value = [
+        "v1.33.0-alpha.0",  # valid pre-release
+        "v1.32.0",  # first stable
+        "v1.32.0-rc.0",
+        "v1.31.5",
+        "v1.31.0-beta.1",
+    ]
+
+    result = k8s_release.get_obsolete_prereleases()
+    assert result == ["v1.32.0-rc.0", "v1.31.0-beta.1"]
+
+
+@patch("util.k8s.get_k8s_tags")
+def test_get_obsolete_prereleases_multiple_valid_prerelease(mock_tags):
+    # Simulate two valid pre-releases
+    mock_tags.return_value = [
+        "v1.33.0-alpha.0",  # valid pre-release
+        "v1.32.0-rc.0",  # valid pre-release
+        "v1.31.5",  # first stable
+        "v1.31.0-beta.1",
+    ]
+
+    result = k8s_release.get_obsolete_prereleases()
+    assert result == ["v1.31.0-beta.1"]
+
+
+@patch("util.k8s.get_k8s_tags")
+@patch("util.k8s.is_stable_release")
+def test_get_obsolete_prereleases_starts_with_stable(mock_is_stable, mock_tags):
+    mock_tags.return_value = [
+        "v1.32.0",
+        "v1.32.0-rc.0",
+        "v1.31.5",
+        "v1.31.0-alpha.1",
+    ]
+    mock_is_stable.side_effect = lambda tag: "-" not in tag
+
+    result = k8s_release.get_obsolete_prereleases()
+    assert result == ["v1.32.0-rc.0", "v1.31.0-alpha.1"]
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("v1.33.0-alpha.0", "autoupdate/v1.33.0-alpha"),
+        ("v1.32.1-beta.3", "autoupdate/v1.32.1-beta"),
+        ("v1.30.2-rc.1", "autoupdate/v1.30.2-rc"),
+        ("v1.30.2-rc.1", "autoupdate/v1.30.2-rc"),
+    ],
+)
+def test_get_prereleases_git_branch_valid(tag, expected):
+    assert k8s_release.get_prerelease_git_branch(tag) == expected
+
+
+@pytest.mark.parametrize(
+    "invalid_tag",
+    [
+        "v1.33.0",
+        "v1.33.0alpha.0",
+        "v1.33.0-stable.1",
+        "1.33.0-alpha.0",
+    ],
+)
+def test_get_prereleases_git_branch_invalid(invalid_tag):
+    with pytest.raises(ValueError):
+        k8s_release.get_prerelease_git_branch(invalid_tag)

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -81,7 +81,7 @@ def _make_channel_map(track: str, risk: str, extra_risk: None | str = None):
 def _mock_k8s_versions(latest_stable: str = "v1.33.0"):
     with (
         mock.patch(
-            "k8s_release.get_latest_stable", new=mock.Mock(return_value=latest_stable)
+            "util.k8s.get_latest_stable", new=mock.Mock(return_value=latest_stable)
         ),
     ):
         yield

--- a/tests/unit/util/test_k8s.py
+++ b/tests/unit/util/test_k8s.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from util.k8s import (get_k8s_tags, get_latest_releases_by_minor,
+                      get_latest_stable, is_stable_release)
+
+SAMPLE_TAGS = [
+    {"name": "v1.33.0-alpha.0"},
+    {"name": "v1.32.0-rc.0"},
+    {"name": "v1.31.6"},
+    {"name": "v1.31.5"},
+    {"name": "v1.30.9"},
+    {"name": "v1.29.10"},
+]
+
+
+@patch("util.k8s._url_get")
+def test_get_k8s_tags(mock_url_get):
+    mock_url_get.return_value = json.dumps(SAMPLE_TAGS)
+    tags = get_k8s_tags()
+    assert tags == [
+        "v1.33.0-alpha.0",
+        "v1.32.0-rc.0",
+        "v1.31.6",
+        "v1.31.5",
+        "v1.30.9",
+        "v1.29.10",
+    ]
+
+
+@patch("util.k8s._url_get")
+def test_get_latest_stable(mock_url_get):
+    mock_url_get.return_value = json.dumps(SAMPLE_TAGS)
+    latest_stable = get_latest_stable()
+    assert latest_stable == "v1.31.6"
+
+
+@patch("util.k8s._url_get")
+def test_get_latest_releases_by_minor(mock_url_get):
+    mock_url_get.return_value = json.dumps(SAMPLE_TAGS)
+    by_minor = get_latest_releases_by_minor()
+    assert by_minor == {
+        "1.33": "v1.33.0-alpha.0",
+        "1.32": "v1.32.0-rc.0",
+        "1.31": "v1.31.6",
+        "1.30": "v1.30.9",
+        "1.29": "v1.29.10",
+    }
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("v1.31.6", True),
+        ("v1.31.0-beta.1", False),
+        ("v1.32.0-rc.0", False),
+        ("v1.33.0-alpha.0", False),
+    ],
+)
+def test_is_stable_release(tag, expected):
+    assert is_stable_release(tag) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,17 @@ passenv =
   PYTHONPATH
   TERM
 
+[testenv:release]
+description = Execute the promote job
+passenv =
+  LPCREDS
+  GITHUB_OUTPUT
+  TEST_*
+  SNAPCRAFT_STORE_CREDENTIALS
+deps =
+    -r{[vars]src_path}/requirements.txt
+commands =
+    python {toxinidir}/scripts/k8s_release.py {posargs}
 
 [testenv:promote]
 description = Execute the promote job
@@ -27,7 +38,7 @@ passenv =
   GITHUB_OUTPUT
   TEST_*
   SNAPCRAFT_STORE_CREDENTIALS
-deps = 
+deps =
     -r{[vars]src_path}/requirements.txt
 commands =
     python {toxinidir}/scripts/promote_tracks.py {posargs}
@@ -35,7 +46,7 @@ commands =
 
 [testenv:format]
 description = Apply coding style standards to code
-deps = 
+deps =
     ruff
     isort
 commands =
@@ -82,4 +93,3 @@ deps =
     bandit[toml]
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]all_path}
-


### PR DESCRIPTION
Right now, only the latest pre-release is supported. However, in transistion times there might be multiple non-stable releases (e.g. 1.33.0-rc1 and 1.34.0-alpha) which both need to be supported.

Also, refactored the common k8s functions and added test-coverage.