### PR TITLE
fix: Fix pre-release check

### DIFF
--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -23,10 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.BOT_SSH_KEY }}
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -48,28 +44,3 @@ jobs:
     secrets: inherit
     with:
       branches: ${{ matrix.branch }}
-  clean-obsolete:
-    runs-on: ubuntu-latest
-    env:
-      CHARMCRAFT_AUTH : ${{ secrets.CHARMCRAFT_AUTH }}
-      LPCREDS_B64: ${{ secrets.LP_CREDS }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ssh-key: ${{ secrets.BOT_SSH_KEY }}
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-      - name: Install Python dependencies
-        shell: bash
-        run: pip3 install -r ./scripts/requirements.txt
-      - name: Clean obsolete branches
-        run: |
-          python3 ./scripts/k8s_release.py remove_obsolete_prereleases

--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -41,10 +41,9 @@ jobs:
   handle-pre-releases:
     name: Handle pre-releases
     needs: [determine]
-    if: ${{ needs.determine.outputs.preReleases != '' }}
     strategy:
       matrix:
-        branch: ${{ fromJson('["' + join('","', split(needs.determine.outputs.gitBranches, '\n')) + '"]') }}
+          branch: ${{ fromJson(needs.determine.outputs.gitBranches) }}
     uses: ./.github/workflows/create-release-branch.yaml
     secrets: inherit
     with:

--- a/scripts/k8s_release.py
+++ b/scripts/k8s_release.py
@@ -92,7 +92,4 @@ if __name__ == "__main__":
     kwargs = vars(parser.parse_args())
     f = locals()[kwargs.pop("subparser")]
     out = f(**kwargs)
-    if isinstance(out, (list, tuple)):
-        print(",".join(out))
-    else:
-        print(out or "")
+    print(out or "")

--- a/scripts/k8s_release.py
+++ b/scripts/k8s_release.py
@@ -63,10 +63,6 @@ def get_prerelease_git_branch(prerelease: str):
     return re.sub(r"(-[a-zA-Z]+)\.[0-9]+", r"\1", branch)
 
 
-def remove_obsolete_prereleases():
-    LOG.warning("TODO: not implemented.")
-
-
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s %(message)s", level=logging.DEBUG)
 
@@ -87,7 +83,6 @@ if __name__ == "__main__":
         help="If set, returns the git branch name of the pre-release instead of the tag.",
         action="store_true",
     )
-    subparsers.add_parser("remove_obsolete_prereleases")
 
     kwargs = vars(parser.parse_args())
     f = locals()[kwargs.pop("subparser")]

--- a/tests/unit/util/test_snapstore.py
+++ b/tests/unit/util/test_snapstore.py
@@ -44,19 +44,9 @@ def test_info_url_error(mock_get):
         snapstore.info("non-existent-snap")
 
 
-@patch("util.snapstore.track_exists", return_value=True)
 @patch("util.snapstore.create_track")
-def test_ensure_track_exists(mock_create_track, mock_track_exists):
+def test_ensure_track_create(mock_create_track):
     snapstore.ensure_track("test-snap", "test-track")
-    mock_track_exists.assert_called_once_with("test-snap", "test-track")
-    mock_create_track.assert_not_called()
-
-
-@patch("util.snapstore.track_exists", return_value=False)
-@patch("util.snapstore.create_track")
-def test_ensure_track_create(mock_create_track, mock_track_exists):
-    snapstore.ensure_track("test-snap", "test-track")
-    mock_track_exists.assert_called_once_with("test-snap", "test-track")
     mock_create_track.assert_called_once_with("test-snap", "test-track")
 
 


### PR DESCRIPTION
Follow-up fix for #29. Invalid workflows are not marked as failed, hence this slipped through.

Also, refactors the `track exists` check to always try to create the track in the snapstore. If it already exists we get a 409 code back which can be ignored.
We need to do this since the unpopulated tracks are not returned by the snap info API.