### PR TITLE
fix: Allow LXD traffic in iptable rules

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -1,5 +1,4 @@
 name: Promote tracks
-
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -1,4 +1,5 @@
 name: Promote tracks
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -67,14 +67,49 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - name: Install lxd and tox
+      - name: Install lxd snap
+        shell: bash
         run: |
-          pip install tox
-          sudo snap install lxd --channel ${{ inputs.lxd-channel }} || true
-          sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
+          # note(ben): Temporary workaround until snapd/snapcraft issue is resolved.
+          sudo apt-get update
+          sudo apt-get install xdelta3 --yes
+
+          if ! snap list lxd &> /dev/null; then
+            echo "Installing lxd snap"
+            sudo snap install lxd --channel ${{ inputs.lxd-channel }}
+          else
+            echo "lxd snap found, refreshing to specified channel"
+            sudo snap refresh lxd --channel ${{ inputs.lxd-channel }}
+          fi
+      - name: Initialize lxd
+        shell: bash
+        run: |
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version
+      # Docker sets iptables rules that interfere with LXD.
+      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+      - name: Apply Docker iptables workaround
+        shell: bash
+        run: |
+          set -x
+          ip a
+          ip r
+
+          bridges=('lxdbr0' 'dualstack-br0' 'ipv6-br0')
+          for i in ${bridges[@]}; do
+            set +e
+            sudo iptables  -I DOCKER-USER -i $i -j ACCEPT
+            sudo ip6tables -I DOCKER-USER -i $i -j ACCEPT
+            sudo iptables  -I DOCKER-USER -o $i -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+            sudo ip6tables -I DOCKER-USER -o $i -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+            set -e
+          done
+      - name: Install tox
+        run: |
+          pip install tox
       - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
         env:
           TEST_SUBSTRATE: lxd

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -71,6 +71,7 @@ jobs:
         shell: bash
         run: |
           # note(ben): Temporary workaround until snapd/snapcraft issue is resolved.
+          export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
           sudo apt-get install xdelta3 --yes
 
@@ -95,9 +96,6 @@ jobs:
         shell: bash
         run: |
           set -x
-          ip a
-          ip r
-
           bridges=('lxdbr0' 'dualstack-br0' 'ipv6-br0')
           for i in ${bridges[@]}; do
             set +e
@@ -120,7 +118,6 @@ jobs:
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_DEFAULT_WAIT_RETRIES: 200
           TEST_DEFAULT_WAIT_DELAY_S: 10
-          TEST_SKIP_CLEANUP: "1"
         run: |
           tox -e promote -- \
             ${{ inputs.dry_run && ' --dry-run' || '' }} \
@@ -139,7 +136,7 @@ jobs:
       - name: Debugging session
         if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: canonical/action-tmate@main
-        timeout-minutes: 1000
+        timeout-minutes: 10
   promote-proposal:
     name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}
     runs-on: ${{ fromJson(inputs.runner-labels) }}

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -85,6 +85,7 @@ jobs:
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_DEFAULT_WAIT_RETRIES: 200
           TEST_DEFAULT_WAIT_DELAY_S: 10
+          TEST_SKIP_CLEANUP: "1"
         run: |
           tox -e promote -- \
             ${{ inputs.dry_run && ' --dry-run' || '' }} \

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Debugging session
         if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: canonical/action-tmate@main
-        timeout-minutes: 10
+        timeout-minutes: 1000
   promote-proposal:
     name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}
     runs-on: ${{ fromJson(inputs.runner-labels) }}


### PR DESCRIPTION
The self-hosted runners container docker with causes issues with docker iptable conflicts.
This PR allows LXD traffic on the hosts again.