### PR TITLE
chore: Improve packaging logic. Add test PPA option

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -33,7 +33,7 @@ on:
         required: false
         description: |-
           A space separated list of architectures to ignore when proposing promotions
-  # pull_request:
+  pull_request:
 
   schedule:
     - cron: '0 0 * * *'  # Runs every midnight

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -33,7 +33,7 @@ on:
         required: false
         description: |-
           A space separated list of architectures to ignore when proposing promotions
-  pull_request:
+  # pull_request:
 
   schedule:
     - cron: '0 0 * * *'  # Runs every midnight

--- a/.github/workflows/publish-k8s-debs.yaml
+++ b/.github/workflows/publish-k8s-debs.yaml
@@ -1,8 +1,6 @@
 name: Build and Publish A Kubernetes Component Debian Package
 
 on:
-  pull_request:
-
   workflow_dispatch:
     inputs:
       component:
@@ -76,16 +74,11 @@ jobs:
           DEBS_FULL_NAME: "${{ secrets.DEBS_FULL_NAME }}"
           DEBS_EMAIL: "${{ secrets.DEBS_EMAIL }}"
           DEBS_LP_ACCOUNT: "${{ secrets.DEBS_LP_ACCOUNT }}"
-        # run: |
-        #   ./scripts/publish_k8s_debs.py \
-        #   --tag "${{ inputs.tag }}" \
-        #   --version-postfix "${{ inputs.version-postfix }}" \
-        #   ${{ inputs.dry-run && '--dry-run' || '' }} \
-        #   ${{ inputs.stable-ppa && '--stable-ppa' || '' }} \
-        #   -l "${{ inputs.log-level }}" \
-        #   "${{ inputs.component }}"
         run: |
           ./scripts/publish_k8s_debs.py \
-          --tag v1.33.0 \
-          --version-postfix 7 \
-          kubeadm
+          --tag "${{ inputs.tag }}" \
+          --version-postfix "${{ inputs.version-postfix }}" \
+          ${{ inputs.dry-run && '--dry-run' || '' }} \
+          ${{ inputs.stable-ppa && '--stable-ppa' || '' }} \
+          -l "${{ inputs.log-level }}" \
+          "${{ inputs.component }}"

--- a/.github/workflows/publish-k8s-debs.yaml
+++ b/.github/workflows/publish-k8s-debs.yaml
@@ -1,10 +1,6 @@
 name: Build and Publish A Kubernetes Component Debian Package
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/publish-k8s-debs.yaml
-      - scripts/publish_k8s_debs.py
   workflow_dispatch:
     inputs:
       component:
@@ -84,5 +80,5 @@ jobs:
           --version-postfix "${{ inputs.version-postfix }}" \
           ${{ inputs.dry-run && '--dry-run' || '' }} \
           ${{ inputs.stable-ppa && '--stable-ppa' || '' }} \
-          ${{ (inputs.log-level != '' && format('-l {0}', inputs.log-level)) || '' }} \
+          -l "${{ inputs.log-level }}" \
           "${{ inputs.component }}"

--- a/.github/workflows/publish-k8s-debs.yaml
+++ b/.github/workflows/publish-k8s-debs.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/publish-k8s-debs.yaml
+      - scripts/publish_k8s_debs.py
   workflow_dispatch:
     inputs:
       component:
@@ -35,6 +36,11 @@ on:
         required: true
         type: string
         default: DEBUG
+      stable-ppa:
+        description: "Upload to stable PPA (true/false). If true, the package will be uploaded to the stable PPA."
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -59,17 +65,24 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt update
-          sudo apt install -y devscripts debhelper dh-make build-essential
+          sudo apt install -y devscripts debhelper dh-make build-essential gnupg dput lintian
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.DEBS_GPG_KEY_PUBLIC_BACKUP }}" > gpg_public.key
+          echo "${{ secrets.DEBS_GPG_KEY_PRIVATE_BACKUP }}" > gpg_private.key
+          gpg --import gpg_public.key
+          gpg --import gpg_private.key
       - name: Build and publish
         env:
-          BOT_GPG_KEY: "${{ secrets.BOT_GPG_KEY }}"
-          BOT_FULL_NAME: "${{ secrets.BOT_FULL_NAME }}"
-          BOT_EMAIL: "${{ secrets.BOT_EMAIL }}"
-          BOT_LP_ACCOUNT: "${{ secrets.BOT_LP_ACCOUNT }}"
+          DEBS_GPG_KEY: "${{ secrets.DEBS_GPG_KEY }}"
+          DEBS_FULL_NAME: "${{ secrets.DEBS_FULL_NAME }}"
+          DEBS_EMAIL: "${{ secrets.DEBS_EMAIL }}"
+          DEBS_LP_ACCOUNT: "${{ secrets.DEBS_LP_ACCOUNT }}"
         run: |
           ./scripts/publish_k8s_debs.py \
-            "${{ inputs.component }}" \
-            ${{ inputs.dry-run && '--dry-run' || '' }} \
-            --tag "${{ inputs.tag }}" \
-            --version-postfix "${{ inputs.version-postfix }}" \
-            --log "${{ inputs.log-level }}"
+          --tag "${{ inputs.tag }}" \
+          --version-postfix "${{ inputs.version-postfix }}" \
+          ${{ inputs.dry-run && '--dry-run' || '' }} \
+          ${{ inputs.stable-ppa && '--stable-ppa' || '' }} \
+          ${{ (inputs.log-level != '' && format('-l {0}', inputs.log-level)) || '' }} \
+          "${{ inputs.component }}"

--- a/.github/workflows/publish-k8s-debs.yaml
+++ b/.github/workflows/publish-k8s-debs.yaml
@@ -1,6 +1,8 @@
 name: Build and Publish A Kubernetes Component Debian Package
 
 on:
+  pull_request:
+
   workflow_dispatch:
     inputs:
       component:
@@ -74,11 +76,16 @@ jobs:
           DEBS_FULL_NAME: "${{ secrets.DEBS_FULL_NAME }}"
           DEBS_EMAIL: "${{ secrets.DEBS_EMAIL }}"
           DEBS_LP_ACCOUNT: "${{ secrets.DEBS_LP_ACCOUNT }}"
+        # run: |
+        #   ./scripts/publish_k8s_debs.py \
+        #   --tag "${{ inputs.tag }}" \
+        #   --version-postfix "${{ inputs.version-postfix }}" \
+        #   ${{ inputs.dry-run && '--dry-run' || '' }} \
+        #   ${{ inputs.stable-ppa && '--stable-ppa' || '' }} \
+        #   -l "${{ inputs.log-level }}" \
+        #   "${{ inputs.component }}"
         run: |
           ./scripts/publish_k8s_debs.py \
-          --tag "${{ inputs.tag }}" \
-          --version-postfix "${{ inputs.version-postfix }}" \
-          ${{ inputs.dry-run && '--dry-run' || '' }} \
-          ${{ inputs.stable-ppa && '--stable-ppa' || '' }} \
-          -l "${{ inputs.log-level }}" \
-          "${{ inputs.component }}"
+          --tag v1.33.0 \
+          --version-postfix 7 \
+          kubeadm

--- a/scripts/templates/publish_k8s_debs/Makefile.j2
+++ b/scripts/templates/publish_k8s_debs/Makefile.j2
@@ -1,10 +1,10 @@
-BINARY := "{{ component }}"
-WHAT := "cmd/${BINARY}"
-KUBE_STATIC_OVERRIDES := "${BINARY}"
+BINARY := {{ component }}
+WHAT := cmd/${BINARY}
+KUBE_STATIC_OVERRIDES := ${BINARY}
 BINDIR := /usr/bin
-DEB_DIR := "${CURDIR}/debian"
-GO_ROOT := "${DEB_DIR}/go"
-OUT_DIR := "${CURDIR}/_output"
+DEB_DIR := ${CURDIR}/debian
+GO_ROOT := ${DEB_DIR}/go
+OUT_DIR := ${CURDIR}/_output
 
 all:
 	make -f Makefile.original WHAT="${WHAT}" KUBE_STATIC_OVERRIDES="${KUBE_STATIC_OVERRIDES}" GOFLAGS="-buildvcs=false" KUBE_GOPATH="${GO_ROOT}"

--- a/scripts/util/repo.py
+++ b/scripts/util/repo.py
@@ -15,7 +15,10 @@ def _parse_output(*args, **kwargs) -> str:
 
 @contextlib.contextmanager
 def clone(
-    repo_url: str, repo_tag: str | None = None, shallow: bool = True
+    repo_url: str,
+    repo_tag: str | None = None,
+    shallow: bool = True,
+    base_dir: str | None = None,
 ) -> Generator[Path, Any, Any]:
     """
     Clone a git repository on a temporary directory and return the directory.
@@ -28,7 +31,7 @@ def clone(
     ```
     """
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(dir=base_dir) as tmpdir:
         cmd = ["git", "clone", repo_url, tmpdir]
         if repo_tag:
             cmd.extend(["-b", repo_tag])


### PR DESCRIPTION
### Overview

This PR improves the logic to build and publish deb packages to Launchpad.
- Use nested tmp directories to enable reproducible builds.
- Add GPG import step
- Add `--stable-ppa` option to enable uploading to a test PPA
- Rename `BOT_` environment variables to `DEBS_` to better convey how/where they should be used.
- Remove debs job from CI:
    - Running the debs jobs on PR is not practical right now because `version postfix` needs to be unique and semantically greater than what is already available in the PPA. Hard coding it will only cause in failed jobs which is not useful. Later on we need to come up with a mechanism to automatically select a deb version postfix to prevent conflicts. 