### PR TITLE
chore: add self hosted runner labels to access SQA API

### DIFF
--- a/.github/workflows/k8s-operator-charm-release.yaml
+++ b/.github/workflows/k8s-operator-charm-release.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   release-charms:
     name: Promotes SQA approved charms
-    runs-on: [self-hosted, linux, AMD64, medium, noble]
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     outputs:
       has_results: ${{ steps.check_results.outputs.has_results }}
     env:


### PR DESCRIPTION
The automation workflow needs to access SQA API on internal network. This PR adds necessary labels to run the workflow on self hosted runners. 