### PR TITLE
ci: Exclude flavor tracks and 1.31 from auto-promotion

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -72,8 +72,8 @@ jobs:
       - name: Assemble auto-promotion Arguments
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
-            # Ignore the 1.30 and strict tracks for auto-promotion. We don't support them.
-            ARGS="$ARGS --ignore-tracks '^1\.\d{2}$' '^1\.30(-.*)?$'"
+            # Ignore the 1.30/31 and flavor tracks for auto-promotion. We don't support them.
+            ARGS="$ARGS --ignore-tracks '^1\\.\d{2}$' '^1\\.\\d{2}-moonray$' '^1\\.30(-.*)?$' '^1\\.31(-.*)?$' "
             echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions


### PR DESCRIPTION
We abandoned the flavor and 1.31 tracks and we should not promote anything there.