### PR TITLE
test: include a specific revision when running the version upgrade tests

### DIFF
--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -44,17 +44,17 @@ on:
         required: true
 jobs:
   test-proposal:
-    name: ${{ join(matrix.upgrade-channel, ' to ')}} on ${{ matrix.lxd-image}}
+    name: ${{ join(matrix.upgrade-channels, ' to ')}} on ${{ matrix.lxd-image}}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
       fail-fast: false
       matrix:
         # a unique runner for each lxd-image and upgrade-path
         lxd-image: ${{ fromJSON(inputs.lxd-images) }}
-        upgrade-channel: ${{ fromJSON(inputs.upgrade-channels) }}
+        upgrade-channels: ${{ fromJSON(inputs.upgrade-channels) }}
     env:
       ARCHITECTURE: ''
-      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channel, ',')}}-${{ matrix.lxd-image }}
+      ARTIFACT_NAME: promotion-test-${{ inputs.proposal-name }}-${{ join(matrix.upgrade-channels, ',')}}-${{ matrix.lxd-image }}
     steps:
       - name: Update ARTIFACT_NAME
         run: |
@@ -108,12 +108,12 @@ jobs:
       - name: Install tox
         run: |
           pip install tox
-      - name: Run promotion tests from ${{ join(matrix.upgrade-channel, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
+      - name: Run promotion tests from ${{ join(matrix.upgrade-channels, ' to ') }} on ${{matrix.lxd-image}}@${{ env.ARCHITECTURE }}
         env:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.lxd-image }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
-          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channel, ' ') }}
+          TEST_VERSION_UPGRADE_CHANNELS: ${{ join(matrix.upgrade-channels, ' ') }}
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_DEFAULT_WAIT_RETRIES: 200

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -148,7 +148,7 @@ def _build_upgrade_channels(
 
     # Only run tests on revision changes
     return [
-        [source, channel.name]
+        [source, f"{channel.name}@{channel.revision}"]
         for source in sorted(source_channels)
         if channel.revision != channels[source].revision
     ]

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -46,7 +46,7 @@ def _create_channel(
 
 def _expected_proposals(track, next_risk, risk, revision, upgrade_channels=None):
     if not upgrade_channels:
-        upgrade_channels = [[f"{track}/stable", f"{track}/{risk}"]]
+        upgrade_channels = [[f"{track}/stable", f"{track}/{risk}@{revision}"]]
 
     return [
         {


### PR DESCRIPTION
This pull request updates the upgrade channel handling in the workflow and test scripts to include channel+revision information and standardizes the naming from `upgrade-channel` to `upgrade-channels` throughout the workflow. This ensures that upgrade paths are more accurately tracked and tested, especially when multiple channels and revisions are involved.

**Workflow and Naming Standardization:**

* Updated `.github/workflows/upgrade-proposal-test.yaml` to use `upgrade-channels` instead of `upgrade-channel` in matrix definitions, job names, and artifact names, ensuring consistency and supporting multiple upgrade channels.
* Modified test step names and environment variables to reference `upgrade-channels`, improving clarity and correctness in test reporting and artifact naming.

**Upgrade Channel Revision Tracking:**

* Changed the `_build_upgrade_channels` function in `scripts/promote_tracks.py` to include channel+revision in the upgrade path (e.g., `channel@revision`), allowing for more precise upgrade testing between specific channel revisions.

Depends on:
* https://github.com/canonical/k8s-snap/pull/2118 and backports