### PR TITLE
Include tox as a dependancy, as its used by promote_tracks.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pydantic~=2.10.6",
     "requests~=2.32.4",
     "semver~=3.0.2",
-    "tox"
+    "tox~=4.32.0"
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.10.6" },
     { name = "requests", specifier = "~=2.32.4" },
     { name = "semver", specifier = "~=3.0.2" },
-    { name = "tox" },
+    { name = "tox", specifier = "~=4.32.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
tox is used when running the promotion job to invoke the tests in k8s snap

https://github.com/canonical/canonical-kubernetes-release-ci/blob/6408e924f29c66034bdd25caf5df1a78a94b19f8/scripts/promote_tracks.py#L52