### PR TITLE
fix: Adjusts the arguments used when calling promote_tracks.py

### DIFF
--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -151,7 +151,7 @@ jobs:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_AUTH_TOKEN }}
       run: |
           tox -e runner -- \
-          scripts/promote_tracks.py -- \
+          scripts/promote_tracks.py \
           ${{ inputs.dry_run && ' --dry-run' || '' }} \
           promote \
           --snap-revision="${{ inputs.revision }}" \


### PR DESCRIPTION
Avoids the issue encountered when running the promote_tracks.py action:

https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/20077808824/job/57597502242