### PR TITLE
Update actions checkout and setup-python

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -28,9 +28,11 @@ jobs:
       LPCREDS: ./lp_creds
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/k8s-operator-charm-release.yaml
+++ b/.github/workflows/k8s-operator-charm-release.yaml
@@ -28,9 +28,11 @@ jobs:
       SQA_API_KEY: ${{ secrets.SQA_API_KEY }}
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/k8s-operator-nightly-sqa-builds.yaml
+++ b/.github/workflows/k8s-operator-nightly-sqa-builds.yaml
@@ -28,9 +28,11 @@ jobs:
       SQA_API_KEY: ${{ secrets.SQA_API_KEY }}
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -15,9 +15,11 @@ jobs:
     env:
       TERM: xterm-256color
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -50,9 +50,11 @@ jobs:
       LPCREDS: ./lp_creds
       ARGS: ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/publish-k8s-debs.yaml
+++ b/.github/workflows/publish-k8s-debs.yaml
@@ -47,9 +47,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/rebuild-release-branch.yaml
+++ b/.github/workflows/rebuild-release-branch.yaml
@@ -31,9 +31,11 @@ jobs:
       LPCREDS: ./lp_creds
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -20,11 +20,13 @@ jobs:
       gitBranches: ${{ steps.determine.outputs.gitBranches }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ssh-key: ${{ secrets.BOT_SSH_KEY }}
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -62,9 +62,11 @@ jobs:
           ARTIFACT_NAME=${ARTIFACT_NAME//\//-}  # replace / with -
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
           echo "ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv tool install tox --with tox-uv
@@ -141,7 +143,10 @@ jobs:
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     needs: test-proposal
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version-file: '.python-version'
     - name: Install uv
       uses: astral-sh/setup-uv@v6
     - run: uv tool install tox --with tox-uv


### PR DESCRIPTION
###Overview

this CI now requires running on python-3.12 and beyond as defined in the pyproject.toml and .python-version files

### Details
* Update to setup-python@v6 and be explicit about the version file
* Update the checkout action

