### PR TITLE
fix: Reduce parallelism of promotion tests to improve test quality

### DIFF
--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         # a unique runner for each lxd-image and upgrade-path
         lxd-image: ${{ fromJSON(inputs.lxd-images) }}


### PR DESCRIPTION
Looking over the history of the [Promotion](https://github.com/canonical/canonical-kubernetes-release-ci/actions/workflows/promotion.yaml) action one will see nearly nightly failures.  Many of the failures can simply be "retried" and they succeed eventually. 

The majority of failures are caused by rate limiting from registry pulls.  By adjusting the max-parallelism, we can slow the image pulls to get under the rate and hopefully improve this pass rate.

* Workflow configuration: Set `max-parallel: 2` in the job matrix strategy in `.github/workflows/upgrade-proposal-test.yaml` to limit the number of concurrent jobs.