### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/upload-inspection-reports/action.yaml
+++ b/.github/actions/upload-inspection-reports/action.yaml
@@ -25,7 +25,7 @@ runs:
       run: |
         tar -czvf ${{ github.workspace }}/inspection-reports.tar.gz -C ${{ inputs.directory }} .
     - name: Upload inspection reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ steps.sanitize.outputs.artifact-name }}
         path: ${{ github.workspace }}/inspection-reports.tar.gz

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -28,13 +28,13 @@ jobs:
       LPCREDS: ./lp_creds
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - name: Install tools
         run: |

--- a/.github/workflows/k8s-operator-charm-release.yaml
+++ b/.github/workflows/k8s-operator-charm-release.yaml
@@ -28,13 +28,13 @@ jobs:
       SQA_API_KEY: ${{ secrets.SQA_API_KEY }}
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - run: sudo snap install weebl-tools --channel latest/edge
       - run: sudo snap install charmcraft --classic --channel=3.x/stable
@@ -73,7 +73,7 @@ jobs:
             echo "has_results=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: results
           path: results.txt
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Set current formatted date as env variable
         run: echo "FORMATTED_DATE=$(date +'%d/%m/%Y')" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: results
       - name: Read results
@@ -94,7 +94,7 @@ jobs:
           ESCAPED=$(sed ':a;N;$!ba;s/\n/\\n/g' results.txt)
           echo "RESULTS_TEXT=$ESCAPED" >> $GITHUB_ENV
       - name: Notify Mattermost
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@d317daebed2a792679f68fd0248557a8d21d82b6 # master
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_BOT_WEBHOOK_URL }}
           PAYLOAD: |

--- a/.github/workflows/k8s-operator-nightly-sqa-builds.yaml
+++ b/.github/workflows/k8s-operator-nightly-sqa-builds.yaml
@@ -28,13 +28,13 @@ jobs:
       SQA_API_KEY: ${{ secrets.SQA_API_KEY }}
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - run: sudo snap install weebl-tools --channel latest/stable
       - run: sudo apt-get install -y gettext
@@ -72,7 +72,7 @@ jobs:
             echo "has_results=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: results
           path: results.txt
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Set current formatted date as env variable
         run: echo "FORMATTED_DATE=$(date +'%d/%m/%Y')" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: results
       - name: Read results
@@ -92,7 +92,7 @@ jobs:
           ESCAPED=$(sed ':a;N;$!ba;s/\n/\\n/g' results.txt)
           echo "RESULTS_TEXT=$ESCAPED" >> $GITHUB_ENV
       - name: Notify Mattermost
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@d317daebed2a792679f68fd0248557a8d21d82b6 # master
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_BOT_WEBHOOK_URL }}
           PAYLOAD: |

--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -15,13 +15,13 @@ jobs:
     env:
       TERM: xterm-256color
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - name: Unit, Lint, Static Analysis
         run: tox -vve unit,lint,static -- --color=yes

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -50,13 +50,13 @@ jobs:
       LPCREDS: ./lp_creds
       ARGS: ''
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - run: 'echo $LPCREDS_B64 | base64 --decode > lp_creds'
       - name: Assemble Dispatch Arguments

--- a/.github/workflows/publish-k8s-debs.yaml
+++ b/.github/workflows/publish-k8s-debs.yaml
@@ -47,13 +47,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - name: Install build dependencies
         run: |

--- a/.github/workflows/rebuild-release-branch.yaml
+++ b/.github/workflows/rebuild-release-branch.yaml
@@ -31,13 +31,13 @@ jobs:
       LPCREDS: ./lp_creds
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - run: 'echo $LPCREDS_B64 | base64 --decode > lp_creds'
       - name: Rebuild Branches

--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -20,15 +20,15 @@ jobs:
       gitBranches: ${{ steps.determine.outputs.gitBranches }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ssh-key: ${{ secrets.BOT_SSH_KEY }}
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - name: Determine outstanding pre-releases
         id: determine

--- a/.github/workflows/upgrade-proposal-test.yaml
+++ b/.github/workflows/upgrade-proposal-test.yaml
@@ -59,16 +59,16 @@ jobs:
     env:
       TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.3
+        uses: canonical/setup-lxd@a3c85fc6fb7fff43fcfeae87659e41a8f635b7dd # v0.1.3
         with:
           channel: ${{ inputs.lxd-channel }}
           bridges: "lxdbr0,dualstack-br0,ipv6-br0"
@@ -95,7 +95,7 @@ jobs:
           directory: ${{ env.TEST_INSPECTION_REPORTS_DIR }}
       - name: Debugging session
         if: ${{ failure() && github.event_name == 'pull_request' }}
-        uses: canonical/action-tmate@main
+        uses: canonical/action-tmate@bda82e73586a62bf621881aab872a527c8a46e2d # main
         timeout-minutes: 10
 
   test-proposal-upgrade:
@@ -111,16 +111,16 @@ jobs:
     env:
       TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: '.python-version'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - run: uv tool install tox --with tox-uv
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.3
+        uses: canonical/setup-lxd@a3c85fc6fb7fff43fcfeae87659e41a8f635b7dd # v0.1.3
         with:
           channel: ${{ inputs.lxd-channel }}
           bridges: "lxdbr0,dualstack-br0,ipv6-br0"
@@ -147,19 +147,19 @@ jobs:
           directory: ${{ env.TEST_INSPECTION_REPORTS_DIR }}
       - name: Debugging session
         if: ${{ failure() && github.event_name == 'pull_request' }}
-        uses: canonical/action-tmate@main
+        uses: canonical/action-tmate@bda82e73586a62bf621881aab872a527c8a46e2d # main
         timeout-minutes: 10
   promote-proposal:
     name: Promote ${{ inputs.revision }} to ${{ inputs.snap-channel }}
     runs-on: ${{ fromJson(inputs.runner-labels) }}
     needs: [test-proposal-upgrade, test-proposal-e2e]
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version-file: '.python-version'
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
     - run: uv tool install tox --with tox-uv
     - run: sudo snap install snapcraft --classic
     - name: Promote


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply-chain security hardening, replacing mutable tag references.

## Why

Mutable tags (e.g. `@v4`) can be moved by upstream maintainers or by an attacker who compromises an action repo. Pinning to a SHA ensures workflows always run exactly the reviewed code.

This follows GitHub's own security hardening guidance and improves our OpenSSF Scorecard rating.

## Changes

- Pinned all third-party and GitHub-maintained actions in workflow files to full 40-character commit SHAs
- Preserved original tag/branch versions in inline comments for readability
- Left already-pinned actions unchanged

## Testing

- Verified all `uses:` references in `.github/workflows/` now use immutable SHAs