### PR TITLE
ci: disable 1.36 release across snap pipelines

### DIFF
--- a/scripts/ensure_snap_builds.py
+++ b/scripts/ensure_snap_builds.py
@@ -62,11 +62,21 @@ def ensure_lp_recipe(
 
     if flavour == "strict":
         LOG.warning(
-            "Disabling snap auto-build for 'strict' flavor, which is currently unsupported."
+            "Disabling snap auto-build and store upload for 'strict' flavor, which is currently unsupported."
         )
         auto_build = False
+        store_upload = False
+    elif (ver.major, ver.minor) in util.DISABLED_TRACKS:
+        LOG.warning(
+            "Disabling snap auto-build and store upload for disabled track %s.%s.",
+            ver.major,
+            ver.minor,
+        )
+        auto_build = False
+        store_upload = False
     else:
         auto_build = True
+        store_upload = True
 
     if ver.prerelease:
         if flavour != "classic":
@@ -118,7 +128,7 @@ def ensure_lp_recipe(
         ],
         store_channels=channels,
         store_name=util.SNAP_NAME,
-        store_upload=True,
+        store_upload=store_upload,
         store_series=lp_snappy_series,
     )
     try:

--- a/scripts/request_builds.py
+++ b/scripts/request_builds.py
@@ -33,10 +33,13 @@ def rebuild_branches(branches: Iterable[str], args: argparse.Namespace):
             version_file = dir / "build-scripts/components/kubernetes/version"
             branch_ver = version_file.read_text().strip()
             ver = semver.Version.parse(branch_ver.strip("v"))
-            flavors = util.flavors(dir)
 
             LOG.info("  Kubernetes version detected %s", branch_ver)
             tip = branch == "main"
+
+            if (ver.major, ver.minor) in util.DISABLED_TRACKS:
+                LOG.info("  Skipping disabled track %s.%s", ver.major, ver.minor)
+                continue
 
             flavors = util.flavors(dir)
             for flavor in flavors:

--- a/scripts/util/util.py
+++ b/scripts/util/util.py
@@ -18,6 +18,9 @@ TIP_BRANCH = re.compile(
 )
 EXEC_TIMEOUT = 60
 
+# Tracks that should not be built or uploaded to the snap store.
+DISABLED_TRACKS: set[tuple[int, int]] = {(1, 36)}
+
 
 def flavors(path: str) -> list[str]:
     """Return a sorted list of available flavors in the given directory."""


### PR DESCRIPTION
## Summary

- Add `--ignore-branches` regex flag to `ensure_snap_builds.py` and `request_builds.py` to skip branch processing by pattern
- Wire `release-1.36` ignore pattern through `create-release-branch.yaml` and `rebuild-release-branch.yaml` workflows

This prevents the 1.36 snap from being built on Launchpad, rebuilt weekly, or promoted through risk channels.