### PR TITLE
fix: drop ubuntu:20.04 from edge-to-beta promotion test matrix

### DIFF
--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -36,7 +36,7 @@ The script will only promote a revision to stable if there is already another re
 The first stable release for each track requires blessing from SolQA and is promoted manually.
 """
 
-SERIES = ["20.04", "22.04", "24.04"]
+SERIES = ["22.04", "24.04"]
 
 IGNORE_TRACKS = ["latest"]
 


### PR DESCRIPTION
Every nightly Promote Tracks run has failed since 2026-07-05 because the `ubuntu:20.04` LXD image deterministically hangs: the `cri-containerd.apparmor.d` AppArmor profile denies `inet` socket creation (hundreds of `audit: apparmor="DENIED" ... family="inet" ... profile="cri-containerd.apparmor.d"` events per run), causing cilium-operator to crash-loop forever and `k8s-dqlite` to never start. All `ubuntu:22.04`/`ubuntu:24.04` jobs in the same runs complete normally in 10-20 minutes.

Root-cause investigation: the denial pattern is a kernel/AppArmor interaction on Ubuntu 20.04's 5.4 kernel with the `cri-containerd.apparmor.d` profile generated by modern containerd. A `disable_apparmor` containerd config knob exists but would be a security regression and would need to land in `canonical/k8s-snap`, not here. LXD `5.21/stable` (pinned in `upgrade-proposal-test.yaml`) shows no relevant AppArmor changelog entries that would address this.

The fix is to remove `"20.04"` from `SERIES`. Ubuntu 20.04 is not a supported base for the k8s snap: the install docs (`docs/canonicalk8s/snap/howto/install/snap.md`) explicitly state "Ubuntu 22.04 or later, or another OS which supports snap packages" as a requirement. Dropping it from CI is aligning the test matrix with the documented support statement, not silently removing coverage of a supported platform.

The `beta->candidate->stable` steps are unaffected; they already use only `SERIES[-1:]` (`ubuntu:24.04`).