### PR TITLE
fix: pin self-hosted promotion runners to jammy host image

### DIFF
--- a/scripts/util/gh.py
+++ b/scripts/util/gh.py
@@ -5,6 +5,23 @@ REPO_RUNNER_LABEL_MAP = {
     "arm64": "ARM64",
 }
 
+# Self-hosted runner base image to pin our jobs to.
+#
+# Our promotion/upgrade tests run LXD containers directly on the runner's
+# host kernel (no nested virtualization), so the container's AppArmor
+# tooling must be compatible with the host kernel's AppArmor ABI. Ubuntu
+# 20.04 LXD containers ship an old apparmor_parser (2.13.3) that cannot
+# parse the AppArmor profile protocol used by Noble (24.04) or Resolute
+# (26.04) host kernels, which causes container creation to fail with:
+#   "apparmor_parser: Unable to replace ... Profile doesn't conform to
+#   protocol": exit status 185
+# This has been observed to reliably break `cilium-operator` (and other
+# pods) on Noble/Resolute hosts, while Jammy (22.04) and Focal (20.04)
+# hosts run all of our supported LXD images (20.04/22.04/24.04) without
+# issue. Pin to Jammy until the AppArmor incompatibility is resolved
+# upstream or we no longer test ubuntu:20.04 LXD images.
+RUNNER_OS_LABEL = "jammy"
+
 
 def arch_to_gh_labels(arch: str, self_hosted: bool = False) -> list[str]:
     labels = []
@@ -12,4 +29,5 @@ def arch_to_gh_labels(arch: str, self_hosted: bool = False) -> list[str]:
         labels.append(label)
     if self_hosted:
         labels.append("self-hosted")
+        labels.append(RUNNER_OS_LABEL)
     return labels

--- a/scripts/util/gh.py
+++ b/scripts/util/gh.py
@@ -28,6 +28,5 @@ def arch_to_gh_labels(arch: str, self_hosted: bool = False) -> list[str]:
     if label := REPO_RUNNER_LABEL_MAP.get(arch):
         labels.append(label)
     if self_hosted:
-        labels.append("self-hosted")
-        labels.append(RUNNER_OS_LABEL)
+        labels.extend(["self-hosted", RUNNER_OS_LABEL])
     return labels

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -58,7 +58,7 @@ def _expected_proposals(track, next_risk, risk, revision, upgrade_channels=None)
             "name": f"k8s-1.31-tracky/{next_risk}-amd64",
             "next-risk": next_risk,
             "revision": revision,
-            "runner-labels": ["X64", "self-hosted"],
+            "runner-labels": ["X64", "self-hosted", "jammy"],
             "snap-channel": f"{track}/{next_risk}",
             "track": track,
             "upgrade-channels": upgrade_channels,


### PR DESCRIPTION
## Problem

Self-hosted promotion/upgrade test jobs (`.github/workflows/upgrade-proposal-test.yaml`) run LXD containers directly on the runner's host kernel — there's no nested virtualization, so the container's AppArmor tooling must be ABI-compatible with the host kernel.

`ubuntu:20.04` LXD guest containers ship an old `apparmor_parser` (2.13.3) that cannot parse the AppArmor profile protocol used by Noble (24.04) / Resolute (26.04) host kernels. When a `ubuntu:20.04` LXD image lands on one of those hosts, container creation fails:

```
failed to create containerd container: load apparmor profile /tmp/cri-containerd.apparmor.d<random>:
parser error("apparmor_parser: Unable to replace \"cri-containerd.apparmor.d\".
Profile doesn't conform to protocol"): exit status 185
```

This reliably breaks `cilium-operator` startup, which cascades into node-not-ready → `test_version_upgrades` retry exhaustion → job failure. This is what caused the failed 1.35 promotion run: [run 31446040578 / job 93641640906](https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/31446040578/job/93641640906).

## Evidence

Aggregated outcomes for `ubuntu:20.04`-labeled matrix jobs across 9 recent daily "Promote tracks" runs, by host runner OS (inferred from runner name):

| Host OS | Success | Failure | Cancelled |
|---|---|---|---|
| Jammy (22.04) | 24 | 0 | 0 |
| Focal (20.04) | 2 | 0 | 0 |
| Noble (24.04) | 0 | 31 | 13 |
| Resolute (26.04) | 0 | 3 | 0 |

Crucially, Noble/Resolute hosts succeed reliably when the LXD **guest** image is `ubuntu:22.04` or `ubuntu:24.04` — the failure is specific to the `ubuntu:20.04` guest combined with a Noble/Resolute host.

## Fix

`runner-labels` is generated once per architecture in `scripts/promote_tracks.py` / `scripts/util/gh.py` (`arch_to_gh_labels`), and applied uniformly to every LXD image in that job's matrix — so we can't selectively target only the `ubuntu:20.04` matrix entry without a bigger restructure. Since Jammy hosts show zero failures across *all* our supported LXD images (20.04/22.04/24.04), the minimal safe fix is to add a `jammy` label to the self-hosted runner selection, pinning these jobs away from Noble/Resolute hosts entirely.

```python
RUNNER_OS_LABEL = "jammy"
...
labels.append("self-hosted")
labels.append(RUNNER_OS_LABEL)
```

## Alternatives considered

- **Pin to `focal` instead of `jammy`**: also 100% success in the data, but the historical sample size is much smaller (2 vs 24), suggesting a smaller runner pool / more scheduling delay. Jammy was chosen for broader capacity.
- **Per-lxd-image runner labels**: would require restructuring proposal generation to be lxd-image-aware (labels are currently set once per arch, shared across the whole `lxd-image` matrix within a job) — bigger change, not done here.
- **Fix AppArmor compatibility itself**: this is an upstream kernel/AppArmor-parser ABI mismatch (see `canonical/charmcraft#2816` for the same failure signature on a different repo), not something we can fix in this repo.

## Testing

- `tox -e unit` — 57 passed
- `tox -e lint` — clean (codespell, ruff format/check, mypy)

## Follow-ups (not in this PR)

- Confirm with runner infra whether `jammy`/`focal`/`noble`/`resolute` are officially registered runner labels (per docs, they are) and whether pinning to `jammy` measurably increases queue times.
- Consider dropping `ubuntu:20.04` as a supported LXD test image, or revisit once the AppArmor incompatibility is fixed upstream.
