### PR TITLE
fix: exclude FIPS-hardened runners from promotion tests

### DIFF
--- a/scripts/util/gh.py
+++ b/scripts/util/gh.py
@@ -22,11 +22,14 @@ REPO_RUNNER_LABEL_MAP = {
 # upstream or we no longer test ubuntu:20.04 LXD images.
 RUNNER_OS_LABEL = "jammy"
 
+# Excludes FIPS/tiobe/private-endpoint specialty pools, which also match `jammy` but aren't general-purpose.
+RUNNER_FLAVOR_LABEL = "generic"
+
 
 def arch_to_gh_labels(arch: str, self_hosted: bool = False) -> list[str]:
     labels = []
     if label := REPO_RUNNER_LABEL_MAP.get(arch):
         labels.append(label)
     if self_hosted:
-        labels.extend(["self-hosted", RUNNER_OS_LABEL])
+        labels.extend(["self-hosted", RUNNER_OS_LABEL, RUNNER_FLAVOR_LABEL])
     return labels

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -58,7 +58,7 @@ def _expected_proposals(track, next_risk, risk, revision, upgrade_channels=None)
             "name": f"k8s-1.31-tracky/{next_risk}-amd64",
             "next-risk": next_risk,
             "revision": revision,
-            "runner-labels": ["X64", "self-hosted", "jammy"],
+            "runner-labels": ["X64", "self-hosted", "jammy", "generic"],
             "snap-channel": f"{track}/{next_risk}",
             "track": track,
             "upgrade-channels": upgrade_channels,


### PR DESCRIPTION
## Problem

After #99 pinned self-hosted runners to `jammy`, jobs now consistently fail on FIPS-hardened Jammy/Noble runners (`*-jammy-medium-fips`, `*-noble-medium-fips`) — the `k8s` snap panics on install:

```
panic: opensslcrypto: FIPS mode requested (system FIPS mode) but not available: OpenSSL 3.0.2 15 Mar 2022
```

This is pre-existing, not caused by #99 — confirmed on a pre-merge run too. Across the last 15 promotion runs, every job on a `*-fips-*` runner failed (36/36). It was previously masked by the larger AppArmor failure rate.

Evidence: [run 1](https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/31603208868) · [run 2](https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/31654765991)

## Fix

`runs-on` label matching is AND-only, so we can't exclude `fips` by name. Per the runner label docs, general-purpose pools carry an additional `generic` label that FIPS/tiobe/private-endpoint pools don't. Adding it restricts scheduling to standard pools:

```python
["X64"/"ARM64", "self-hosted", "jammy", "generic"]
```

## Testing

- `tox -e unit` (57 passed), `tox -e lint` (clean)
- Verified `gh.arch_to_gh_labels("amd64", self_hosted=True)` → `['X64', 'self-hosted', 'jammy', 'generic']`

Draft — holding for review before merge.
