### PR TITLE
ci: add ubuntu 26.04 (resolute) to promotion test series

### DIFF
--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -36,7 +36,7 @@ The script will only promote a revision to stable if there is already another re
 The first stable release for each track requires blessing from SolQA and is promoted manually.
 """
 
-SERIES = ["20.04", "22.04", "24.04"]
+SERIES = ["20.04", "22.04", "24.04", "26.04"]
 
 IGNORE_TRACKS = ["latest"]
 

--- a/scripts/util/sqa.py
+++ b/scripts/util/sqa.py
@@ -48,6 +48,7 @@ class BuildResult(StrEnum):
 
 def get_series(base: str) -> str | None:
     base_series_map = {
+        "26.04": "resolute",
         "24.04": "noble",
         "22.04": "jammy",
         "20.04": "focal",


### PR DESCRIPTION
## Summary

Adds Ubuntu 26.04 (Resolute) to the snap promotion test series so the promotion pipeline validates snaps on the new LTS.

## Changes

- `scripts/promote_tracks.py`: add `"26.04"` to `SERIES`
- `scripts/util/sqa.py`: add `"26.04": "resolute"` to the `get_series()` codename map

## Acceptance criteria

- [x] Promotion test series extended to include 26.04
- [x] Codename mapping added for resolute