### PR TITLE
CI: hold 1.36-classic at candidate via a generalized --ignore-tracks ceiling

### DIFF
--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -76,7 +76,8 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
             # Ignore the 1.30/31 and flavor tracks for auto-promotion. We don't support them.
-            ARGS="$ARGS --ignore-tracks '^1\\.\d{2}$' '^1\\.\\d{2}-moonray$' '^1\\.30(-.*)?$' '^1\\.31(-.*)?$' "
+            # Hold 1.36-classic at candidate: validated manually, never auto-promote to stable.
+            ARGS="$ARGS --ignore-tracks '^1\\.\d{2}$' '^1\\.\\d{2}-moonray$' '^1\\.30(-.*)?$' '^1\\.31(-.*)?$' '1\\.36-classic:candidate' "
             echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -27,13 +27,11 @@ on:
         type: string
         required: false
         description: |-
-          A space separated list of tracks to ignore when proposing promotions
-      ignore_stable_tracks:
-        type: string
-        required: false
-        description: |-
-          A space separated list of track regexes (fullmatch) to keep at candidate,
-          never auto-promoting them to stable
+          A space separated list of tracks to ignore when proposing promotions. Each
+          entry is a fullmatch regex, optionally suffixed `:CEILING` (edge, beta, or
+          candidate) to cap a track at that risk level instead of freezing it entirely,
+          e.g. '1\.36-classic:candidate' holds a track at candidate, never promoting
+          it to stable.
       ignore_architectures:
         type: string
         required: false
@@ -72,7 +70,6 @@ jobs:
           ARGS="$ARGS --days-in-beta-risk ${{ inputs.days_in_beta_risk }}"
           ARGS="$ARGS --days-in-candidate-risk ${{ inputs.days_in_candidate_risk }}"
           ARGS="$ARGS --ignore-tracks ${{ inputs.ignore_tracks }}"
-          ARGS="$ARGS --ignore-stable-tracks ${{ inputs.ignore_stable_tracks }}"
           ARGS="$ARGS --ignore-arches ${{ inputs.ignore_architectures }}"
           echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Assemble auto-promotion Arguments

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
             # Ignore the 1.30/31 and flavor tracks for auto-promotion. We don't support them.
             # Hold 1.36-classic at candidate: validated manually, never auto-promote to stable.
-            ARGS="$ARGS --ignore-tracks '^1\\.\d{2}$' '^1\\.\\d{2}-moonray$' '^1\\.30(-.*)?$' '^1\\.31(-.*)?$' '1\\.36-classic:candidate' "
+            ARGS="$ARGS --ignore-tracks ^1\.\d{2}$ ^1\.\d{2}-moonray$ ^1\.30(-.*)?$ ^1\.31(-.*)?$ 1\.36-classic:candidate "
             echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Propose Promotions
         id: propose-promotions

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -28,6 +28,12 @@ on:
         required: false
         description: |-
           A space separated list of tracks to ignore when proposing promotions
+      ignore_stable_tracks:
+        type: string
+        required: false
+        description: |-
+          A space separated list of track regexes (fullmatch) to keep at candidate,
+          never auto-promoting them to stable
       ignore_architectures:
         type: string
         required: false
@@ -66,6 +72,7 @@ jobs:
           ARGS="$ARGS --days-in-beta-risk ${{ inputs.days_in_beta_risk }}"
           ARGS="$ARGS --days-in-candidate-risk ${{ inputs.days_in_candidate_risk }}"
           ARGS="$ARGS --ignore-tracks ${{ inputs.ignore_tracks }}"
+          ARGS="$ARGS --ignore-stable-tracks ${{ inputs.ignore_stable_tracks }}"
           ARGS="$ARGS --ignore-arches ${{ inputs.ignore_architectures }}"
           echo "ARGS=$ARGS" >> $GITHUB_ENV
       - name: Assemble auto-promotion Arguments

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -37,17 +37,14 @@ The first stable release for each track requires blessing from SolQA and is prom
 --ignore-tracks entries are `PATTERN` (frozen: never promoted at any risk level) or
    `PATTERN:CEILING` (capped: promoted normally up through CEILING, never past it),
    where CEILING is one of edge, beta, or candidate.
-By default the '1.36-classic' track is capped at candidate and never promoted to stable.
 """
 
 SERIES = ["20.04", "22.04", "24.04"]
 
 # Tracks matching a bare pattern are frozen (never promoted at any risk level).
-# Tracks matching a `(pattern, ceiling)` pair are capped at that risk level,
-# regardless of how the script is invoked (scheduled or manually dispatched).
+# Tracks matching a `(pattern, ceiling)` pair are capped at that risk level.
 IGNORE_TRACKS: list[tuple[str, Optional[str]]] = [
     ("latest", None),
-    (r"1\.36-classic", "candidate"),
 ]
 
 # The snap risk levels, used to find the next risk level for a revision.

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -34,11 +34,17 @@ Each revision is promoted after being at a risk level for a certain amount of da
 The script will only promote a revision to stable if there is already another revision
    for this track at stable.
 The first stable release for each track requires blessing from SolQA and is promoted manually.
+Tracks matching --ignore-stable-tracks are promoted up to candidate but held there,
+   never auto-promoted to stable.
 """
 
 SERIES = ["20.04", "22.04", "24.04"]
 
 IGNORE_TRACKS = ["latest"]
+
+# Tracks held at candidate: never auto-promoted to stable, regardless of how
+# the script is invoked (scheduled or manually dispatched).
+IGNORE_STABLE_TRACKS = [r"1\.36-classic"]
 
 # The snap risk levels, used to find the next risk level for a revision.
 RISK_LEVELS = ["edge", "beta", "candidate", "stable"]
@@ -207,6 +213,7 @@ def _get_series(next_risk: str) -> list[str]:
 def _create_arch_proposals(arch, channels: dict[str, Channel], args):
     proposals = []
     ignored_tracks = IGNORE_TRACKS + getattr(args, "ignore_tracks", [])
+    ignored_stable_tracks = IGNORE_STABLE_TRACKS + getattr(args, "ignore_stable_tracks", [])
     ignored_arches = getattr(args, "ignore_arches", [])
     days_to_stay_in_risk = {
         "edge": args.days_in_edge_risk,
@@ -216,6 +223,9 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
 
     def sorter(info: Channel):
         return (info.name, RISK_LEVELS.index(info.risk))
+
+    def matched_pattern(patterns: list[str], track: str) -> Optional[str]:
+        return next((pattern for pattern in patterns if re.fullmatch(pattern, track)), None)
 
     latest_upstream_stable = k8s.get_latest_stable()
     for channel_info in sorted(channels.values(), key=sorter, reverse=True):
@@ -233,18 +243,20 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             chan_log.debug("Skipping promoting stable")
             continue
 
-        matched_pattern = next(
-            (pattern for pattern in ignored_tracks if re.fullmatch(pattern, track)),
-            None,
-        )
-        if matched_pattern:
-            chan_log.debug(
-                f"Skipping ignored track '{track}' (matched pattern: '{matched_pattern}')"
-            )
+        if ignored := matched_pattern(ignored_tracks, track):
+            chan_log.debug(f"Skipping ignored track '{track}' (matched pattern: '{ignored}')")
             continue
 
         if arch in ignored_arches:
             chan_log.debug("Skipping ignored architecture")
+            continue
+
+        held_at_candidate = matched_pattern(ignored_stable_tracks, track)
+        if next_risk == "stable" and held_at_candidate:
+            chan_log.info(
+                f"Skipping promotion of track '{track}' to stable "
+                f"(matched --ignore-stable-tracks pattern: '{held_at_candidate}')"
+            )
             continue
 
         now = datetime.datetime.now(datetime.timezone.utc)
@@ -294,10 +306,18 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
         # and promote it to all risk levels, including stable.
         # We'll only do this for the latest upstream release
         # and channels that do not have a stable release yet.
+        # Tracks held at candidate never take this fast path: since they never
+        # reach stable, revision_in_stable would stay False forever, and this
+        # branch would otherwise re-fire on every new patch, skipping the
+        # beta/candidate purgatory soak entirely.
         if not revision_in_stable:
             k8s_version = channel_info.version
 
-            if new_patch_in_edge and k8s_version == latest_upstream_stable:
+            if (
+                new_patch_in_edge
+                and k8s_version == latest_upstream_stable
+                and not held_at_candidate
+            ):
                 chan_log.info(
                     f"{track}/edge contains a stable upstream release: {k8s_version}, "
                     "we'll skip purgatory and promote it to all risk levels "
@@ -446,6 +466,12 @@ def main():
         "--ignore-tracks",
         nargs="*",
         help="Tracks to ignore when proposing revisions",
+        default=[],
+    )
+    propose_args.add_argument(
+        "--ignore-stable-tracks",
+        nargs="*",
+        help="Track regexes (fullmatch) to keep at candidate; never auto-promote to stable",
         default=[],
     )
     propose_args.add_argument(

--- a/scripts/promote_tracks.py
+++ b/scripts/promote_tracks.py
@@ -34,17 +34,21 @@ Each revision is promoted after being at a risk level for a certain amount of da
 The script will only promote a revision to stable if there is already another revision
    for this track at stable.
 The first stable release for each track requires blessing from SolQA and is promoted manually.
-Tracks matching --ignore-stable-tracks are promoted up to candidate but held there,
-   never auto-promoted to stable.
+--ignore-tracks entries are `PATTERN` (frozen: never promoted at any risk level) or
+   `PATTERN:CEILING` (capped: promoted normally up through CEILING, never past it),
+   where CEILING is one of edge, beta, or candidate.
+By default the '1.36-classic' track is capped at candidate and never promoted to stable.
 """
 
 SERIES = ["20.04", "22.04", "24.04"]
 
-IGNORE_TRACKS = ["latest"]
-
-# Tracks held at candidate: never auto-promoted to stable, regardless of how
-# the script is invoked (scheduled or manually dispatched).
-IGNORE_STABLE_TRACKS = [r"1\.36-classic"]
+# Tracks matching a bare pattern are frozen (never promoted at any risk level).
+# Tracks matching a `(pattern, ceiling)` pair are capped at that risk level,
+# regardless of how the script is invoked (scheduled or manually dispatched).
+IGNORE_TRACKS: list[tuple[str, Optional[str]]] = [
+    ("latest", None),
+    (r"1\.36-classic", "candidate"),
+]
 
 # The snap risk levels, used to find the next risk level for a revision.
 RISK_LEVELS = ["edge", "beta", "candidate", "stable"]
@@ -56,6 +60,26 @@ DAYS_TO_STAY_IN_BETA = 1
 DAYS_TO_STAY_IN_CANDIDATE = 1
 
 TRACK_RE = re.compile(r"^(\d+)\.(\d+)(\S*)$")
+
+
+def _parse_ignore_track(entry: str) -> tuple[str, Optional[str]]:
+    """Parse a `--ignore-tracks` entry: `PATTERN` (frozen) or `PATTERN:CEILING`.
+
+    CEILING is the highest risk level (edge, beta, or candidate) the track may
+    ever be promoted to; the track is never promoted past it. A bare pattern
+    with no `:CEILING` suffix freezes the track at every risk level.
+    """
+    pattern, sep, ceiling = entry.rpartition(":")
+    if not sep or not ceiling.isalpha():
+        # No `:` at all, or the tail isn't a bare word (e.g. a `(?:...)` group
+        # inside the regex itself) — treat the whole entry as the pattern.
+        return entry, None
+    if ceiling not in RISK_LEVELS[:-1]:
+        raise argparse.ArgumentTypeError(
+            f"Invalid risk ceiling '{ceiling}' in --ignore-tracks entry '{entry}'; "
+            f"must be one of {RISK_LEVELS[:-1]}"
+        )
+    return pattern, ceiling
 
 
 class ProposalTestError(Exception):
@@ -213,19 +237,31 @@ def _get_series(next_risk: str) -> list[str]:
 def _create_arch_proposals(arch, channels: dict[str, Channel], args):
     proposals = []
     ignored_tracks = IGNORE_TRACKS + getattr(args, "ignore_tracks", [])
-    ignored_stable_tracks = IGNORE_STABLE_TRACKS + getattr(args, "ignore_stable_tracks", [])
     ignored_arches = getattr(args, "ignore_arches", [])
     days_to_stay_in_risk = {
         "edge": args.days_in_edge_risk,
         "beta": args.days_in_beta_risk,
         "candidate": args.days_in_candidate_risk,
     }
+    unrestricted = len(RISK_LEVELS) - 1  # index of "stable": no promotion cap
 
     def sorter(info: Channel):
         return (info.name, RISK_LEVELS.index(info.risk))
 
-    def matched_pattern(patterns: list[str], track: str) -> Optional[str]:
-        return next((pattern for pattern in patterns if re.fullmatch(pattern, track)), None)
+    def risk_ceiling(track: str) -> tuple[int, Optional[str]]:
+        """Return (max risk index the track may reach, matched pattern).
+
+        -1 means the track is frozen (never promoted at any risk level).
+        `unrestricted` means the track has no cap (default, no match).
+        The most restrictive matching entry wins, so a built-in default can be
+        tightened by a `--ignore-tracks` argument but never loosened by one.
+        """
+        matches = [
+            ((-1 if ceiling is None else RISK_LEVELS.index(ceiling)), pattern)
+            for pattern, ceiling in ignored_tracks
+            if re.fullmatch(pattern, track)
+        ]
+        return min(matches, default=(unrestricted, None))
 
     latest_upstream_stable = k8s.get_latest_stable()
     for channel_info in sorted(channels.values(), key=sorter, reverse=True):
@@ -243,19 +279,20 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
             chan_log.debug("Skipping promoting stable")
             continue
 
-        if ignored := matched_pattern(ignored_tracks, track):
-            chan_log.debug(f"Skipping ignored track '{track}' (matched pattern: '{ignored}')")
+        max_risk_index, matched = risk_ceiling(track)
+        if max_risk_index < 0:
+            chan_log.debug(f"Skipping ignored track '{track}' (matched pattern: '{matched}')")
             continue
 
         if arch in ignored_arches:
             chan_log.debug("Skipping ignored architecture")
             continue
 
-        held_at_candidate = matched_pattern(ignored_stable_tracks, track)
-        if next_risk == "stable" and held_at_candidate:
+        held = max_risk_index < unrestricted
+        if RISK_LEVELS.index(next_risk) > max_risk_index:
             chan_log.info(
-                f"Skipping promotion of track '{track}' to stable "
-                f"(matched --ignore-stable-tracks pattern: '{held_at_candidate}')"
+                f"Skipping promotion of track '{track}' past {RISK_LEVELS[max_risk_index]} "
+                f"(matched pattern: '{matched}')"
             )
             continue
 
@@ -306,18 +343,14 @@ def _create_arch_proposals(arch, channels: dict[str, Channel], args):
         # and promote it to all risk levels, including stable.
         # We'll only do this for the latest upstream release
         # and channels that do not have a stable release yet.
-        # Tracks held at candidate never take this fast path: since they never
-        # reach stable, revision_in_stable would stay False forever, and this
-        # branch would otherwise re-fire on every new patch, skipping the
-        # beta/candidate purgatory soak entirely.
+        # A track capped below stable never takes this fast path: since it
+        # never reaches stable, revision_in_stable would stay False forever,
+        # and this branch would otherwise re-fire on every new patch, skipping
+        # the beta/candidate purgatory soak entirely.
         if not revision_in_stable:
             k8s_version = channel_info.version
 
-            if (
-                new_patch_in_edge
-                and k8s_version == latest_upstream_stable
-                and not held_at_candidate
-            ):
+            if new_patch_in_edge and k8s_version == latest_upstream_stable and not held:
                 chan_log.info(
                     f"{track}/edge contains a stable upstream release: {k8s_version}, "
                     "we'll skip purgatory and promote it to all risk levels "
@@ -465,13 +498,13 @@ def main():
     propose_args.add_argument(
         "--ignore-tracks",
         nargs="*",
-        help="Tracks to ignore when proposing revisions",
-        default=[],
-    )
-    propose_args.add_argument(
-        "--ignore-stable-tracks",
-        nargs="*",
-        help="Track regexes (fullmatch) to keep at candidate; never auto-promote to stable",
+        type=_parse_ignore_track,
+        help=(
+            "Tracks to ignore when proposing revisions. Each entry is a fullmatch regex, "
+            "optionally suffixed `:CEILING` (edge, beta, or candidate) to cap the track at "
+            "that risk level instead of freezing it entirely, e.g. "
+            r"'1\.36-classic:candidate' holds a track at candidate, never promoting to stable."
+        ),
         default=[],
     )
     propose_args.add_argument(

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -20,6 +20,15 @@ args = argparse.Namespace(
 
 
 @pytest.fixture(autouse=True)
+def reset_args():
+    """Snapshot/restore the shared `args` Namespace so tests can't leak state."""
+    original = vars(args).copy()
+    yield
+    vars(args).clear()
+    vars(args).update(original)
+
+
+@pytest.fixture(autouse=True)
 def branch_from_track():
     with mock.patch("util.lp.branch_from_track") as mocked:
         mocked.return_value = MOCK_BRANCH
@@ -155,6 +164,74 @@ def test_ignored_tracks(track, ignored_patterns, expected_ignored):
         proposals = promote_tracks.create_proposal(args)
     assert (len(proposals) == 0) == expected_ignored, (
         f"Track '{track}' should {'be ignored' if expected_ignored else 'not be ignored'}"
+    )
+
+
+@pytest.mark.parametrize(
+    "track, ignored_stable_patterns, expected_held_at_candidate",
+    [
+        ("1.40-classic", [r"1\.40-classic"], True),  # Exact match
+        ("1.40-classic", [r"1\.\d+-classic"], True),  # Regex match
+        ("1.41-classic", [r"1\.40-classic"], False),  # No match
+        ("1.40-classic", [], False),  # Nothing ignored
+    ],
+)
+@mock.patch("promote_tracks.SERIES", MOCK_SERIES)
+def test_ignore_stable_tracks(track, ignored_stable_patterns, expected_held_at_candidate):
+    with (
+        freeze_time("2000-01-02"),
+        _make_channel_map(track, "candidate", extra_risk="stable"),
+        _mock_k8s_versions(),
+    ):
+        args.ignore_stable_tracks = ignored_stable_patterns
+        proposals = promote_tracks.create_proposal(args)
+    expected_channels = [] if expected_held_at_candidate else [f"{track}/stable"]
+    assert [p["snap-channel"] for p in proposals] == expected_channels, (
+        f"Track '{track}' should "
+        f"{'be held at candidate' if expected_held_at_candidate else 'be promoted to stable'}"
+    )
+
+
+@mock.patch("promote_tracks.SERIES", MOCK_SERIES)
+def test_ignore_stable_tracks_default_holds_1_36_classic():
+    # 1.36-classic is held at candidate unconditionally, even with no
+    # --ignore-stable-tracks argument (e.g. a manual workflow_dispatch run).
+    with (
+        freeze_time("2000-01-02"),
+        _make_channel_map("1.36-classic", "candidate", extra_risk="stable"),
+        _mock_k8s_versions(),
+    ):
+        proposals = promote_tracks.create_proposal(args)
+    assert proposals == [], "1.36-classic must stay at candidate by default"
+
+
+@mock.patch("promote_tracks.SERIES", MOCK_SERIES)
+def test_ignore_stable_tracks_does_not_block_lower_risks():
+    # A track held at candidate must still be promoted through edge/beta/candidate.
+    with (
+        freeze_time("2000-01-02"),
+        _make_channel_map(MOCK_TRACK, "beta", extra_risk="stable"),
+        _mock_k8s_versions(),
+    ):
+        args.ignore_stable_tracks = [r"1\.\d+-tracky"]
+        proposals = promote_tracks.create_proposal(args)
+    assert proposals == _expected_proposals(MOCK_TRACK, "candidate", "beta", 2)
+
+
+@mock.patch("promote_tracks.SERIES", MOCK_SERIES)
+def test_ignore_stable_tracks_holds_new_stable_bootstrap():
+    # A track held at candidate must not take the "new stable upstream release"
+    # fast path either: it must still be promoted one purgatory-gated step at a
+    # time (edge->beta here), never batched straight through to stable.
+    with (
+        _make_channel_map(MOCK_TRACK, "edge"),
+        _mock_k8s_versions("v1.31.0"),
+    ):
+        args.ignore_stable_tracks = [r"1\.\d+-tracky"]
+        proposals = promote_tracks.create_proposal(args)
+    exp_upgrade_channels = [[f"{MOCK_TRACK}/edge"]]
+    assert proposals == _expected_proposals(
+        MOCK_TRACK, "beta", "edge", 2, upgrade_channels=exp_upgrade_channels
     )
 
 

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -239,19 +239,6 @@ def test_ignore_tracks_most_restrictive_wins():
 
 
 @mock.patch("promote_tracks.SERIES", MOCK_SERIES)
-def test_ignore_tracks_default_holds_1_36_classic():
-    # 1.36-classic is held at candidate unconditionally, even with no
-    # --ignore-tracks argument (e.g. a manual workflow_dispatch run).
-    with (
-        freeze_time("2000-01-02"),
-        _make_channel_map("1.36-classic", "candidate", extra_risk="stable"),
-        _mock_k8s_versions(),
-    ):
-        proposals = promote_tracks.create_proposal(args)
-    assert proposals == [], "1.36-classic must stay at candidate by default"
-
-
-@mock.patch("promote_tracks.SERIES", MOCK_SERIES)
 def test_ignore_tracks_ceiling_does_not_block_lower_risks():
     # A track held at candidate must still be promoted through edge/beta/candidate.
     with (

--- a/tests/unit/test_promote_tracks.py
+++ b/tests/unit/test_promote_tracks.py
@@ -150,7 +150,7 @@ def test_latest_track(risk, now):
 
 
 @pytest.mark.parametrize(
-    "track, ignored_patterns, expected_ignored",
+    "track, ignored_entries, expected_ignored",
     [
         ("1.31", ["1.31", r"1\.\d+-classic"], True),  # Exact match
         ("1.31-classic", ["1\\.31", r"1\.\d+-classic"], True),  # Regex match
@@ -158,9 +158,9 @@ def test_latest_track(risk, now):
         ("1.31-classic", [], False),  # Nothing ignored
     ],
 )
-def test_ignored_tracks(track, ignored_patterns, expected_ignored):
+def test_ignore_tracks_frozen(track, ignored_entries, expected_ignored):
     with _make_channel_map(track, "edge"), _mock_k8s_versions():
-        args.ignore_tracks = ignored_patterns
+        args.ignore_tracks = [promote_tracks._parse_ignore_track(e) for e in ignored_entries]
         proposals = promote_tracks.create_proposal(args)
     assert (len(proposals) == 0) == expected_ignored, (
         f"Track '{track}' should {'be ignored' if expected_ignored else 'not be ignored'}"
@@ -168,22 +168,44 @@ def test_ignored_tracks(track, ignored_patterns, expected_ignored):
 
 
 @pytest.mark.parametrize(
-    "track, ignored_stable_patterns, expected_held_at_candidate",
+    "entry, expected",
     [
-        ("1.40-classic", [r"1\.40-classic"], True),  # Exact match
-        ("1.40-classic", [r"1\.\d+-classic"], True),  # Regex match
-        ("1.41-classic", [r"1\.40-classic"], False),  # No match
+        ("1.31", ("1.31", None)),
+        (r"1\.36-classic:candidate", (r"1\.36-classic", "candidate")),
+        ("latest:edge", ("latest", "edge")),
+        # A literal `:` from regex syntax (non-capturing group), not a ceiling
+        # suffix, must be left untouched.
+        (r"^1\.3(?:0|1)(-.*)?$", (r"^1\.3(?:0|1)(-.*)?$", None)),
+    ],
+)
+def test_parse_ignore_track(entry, expected):
+    assert promote_tracks._parse_ignore_track(entry) == expected
+
+
+def test_parse_ignore_track_rejects_invalid_ceiling():
+    with pytest.raises(argparse.ArgumentTypeError):
+        promote_tracks._parse_ignore_track("1.36-classic:stale")
+
+
+@pytest.mark.parametrize(
+    "track, ignored_entries, expected_held_at_candidate",
+    [
+        ("1.40-classic", ["1\\.40-classic:candidate"], True),  # Exact match
+        ("1.40-classic", [r"1\.\d+-classic:candidate"], True),  # Regex match
+        ("1.41-classic", ["1\\.40-classic:candidate"], False),  # No match
         ("1.40-classic", [], False),  # Nothing ignored
+        ("1.40-classic", [r"1\.\d+-classic:beta"], True),  # Stricter ceiling
+        ("1.40-classic", [r"1\.\d+-classic:edge"], True),  # Lowest ceiling
     ],
 )
 @mock.patch("promote_tracks.SERIES", MOCK_SERIES)
-def test_ignore_stable_tracks(track, ignored_stable_patterns, expected_held_at_candidate):
+def test_ignore_tracks_ceiling(track, ignored_entries, expected_held_at_candidate):
     with (
         freeze_time("2000-01-02"),
         _make_channel_map(track, "candidate", extra_risk="stable"),
         _mock_k8s_versions(),
     ):
-        args.ignore_stable_tracks = ignored_stable_patterns
+        args.ignore_tracks = [promote_tracks._parse_ignore_track(e) for e in ignored_entries]
         proposals = promote_tracks.create_proposal(args)
     expected_channels = [] if expected_held_at_candidate else [f"{track}/stable"]
     assert [p["snap-channel"] for p in proposals] == expected_channels, (
@@ -193,9 +215,33 @@ def test_ignore_stable_tracks(track, ignored_stable_patterns, expected_held_at_c
 
 
 @mock.patch("promote_tracks.SERIES", MOCK_SERIES)
-def test_ignore_stable_tracks_default_holds_1_36_classic():
+def test_ignore_tracks_ceiling_allows_promotion_up_to_ceiling():
+    # A track capped at beta must still be promoted edge->beta: reaching the
+    # ceiling exactly is allowed, only exceeding it is blocked.
+    with (
+        freeze_time("2000-01-02"),
+        _make_channel_map(MOCK_TRACK, "edge", extra_risk="stable"),
+        _mock_k8s_versions(),
+    ):
+        args.ignore_tracks = [promote_tracks._parse_ignore_track(r"1\.\d+-tracky:beta")]
+        proposals = promote_tracks.create_proposal(args)
+    assert proposals == _expected_proposals(MOCK_TRACK, "beta", "edge", 2)
+
+
+@mock.patch("promote_tracks.IGNORE_TRACKS", [(MOCK_TRACK, "candidate")])
+def test_ignore_tracks_most_restrictive_wins():
+    # A CLI freeze must win over a laxer built-in cap for the same track, even
+    # though built-in entries are scanned first.
+    with _make_channel_map(MOCK_TRACK, "edge"), _mock_k8s_versions():
+        args.ignore_tracks = [promote_tracks._parse_ignore_track(MOCK_TRACK)]
+        proposals = promote_tracks.create_proposal(args)
+    assert proposals == [], "Explicit freeze must not be loosened by a laxer built-in cap"
+
+
+@mock.patch("promote_tracks.SERIES", MOCK_SERIES)
+def test_ignore_tracks_default_holds_1_36_classic():
     # 1.36-classic is held at candidate unconditionally, even with no
-    # --ignore-stable-tracks argument (e.g. a manual workflow_dispatch run).
+    # --ignore-tracks argument (e.g. a manual workflow_dispatch run).
     with (
         freeze_time("2000-01-02"),
         _make_channel_map("1.36-classic", "candidate", extra_risk="stable"),
@@ -206,20 +252,20 @@ def test_ignore_stable_tracks_default_holds_1_36_classic():
 
 
 @mock.patch("promote_tracks.SERIES", MOCK_SERIES)
-def test_ignore_stable_tracks_does_not_block_lower_risks():
+def test_ignore_tracks_ceiling_does_not_block_lower_risks():
     # A track held at candidate must still be promoted through edge/beta/candidate.
     with (
         freeze_time("2000-01-02"),
         _make_channel_map(MOCK_TRACK, "beta", extra_risk="stable"),
         _mock_k8s_versions(),
     ):
-        args.ignore_stable_tracks = [r"1\.\d+-tracky"]
+        args.ignore_tracks = [promote_tracks._parse_ignore_track(r"1\.\d+-tracky:candidate")]
         proposals = promote_tracks.create_proposal(args)
     assert proposals == _expected_proposals(MOCK_TRACK, "candidate", "beta", 2)
 
 
 @mock.patch("promote_tracks.SERIES", MOCK_SERIES)
-def test_ignore_stable_tracks_holds_new_stable_bootstrap():
+def test_ignore_tracks_ceiling_holds_new_stable_bootstrap():
     # A track held at candidate must not take the "new stable upstream release"
     # fast path either: it must still be promoted one purgatory-gated step at a
     # time (edge->beta here), never batched straight through to stable.
@@ -227,7 +273,7 @@ def test_ignore_stable_tracks_holds_new_stable_bootstrap():
         _make_channel_map(MOCK_TRACK, "edge"),
         _mock_k8s_versions("v1.31.0"),
     ):
-        args.ignore_stable_tracks = [r"1\.\d+-tracky"]
+        args.ignore_tracks = [promote_tracks._parse_ignore_track(r"1\.\d+-tracky:candidate")]
         proposals = promote_tracks.create_proposal(args)
     exp_upgrade_channels = [[f"{MOCK_TRACK}/edge"]]
     assert proposals == _expected_proposals(


### PR DESCRIPTION
Stop auto-promoting `1.36-classic` to stable. Promotion up to candidate is unaffected.

Generalizes `--ignore-tracks` instead of adding a separate flag. Each entry is now `PATTERN` (frozen: never promoted at any risk level, unchanged) or `PATTERN:CEILING` where `CEILING` is `edge`, `beta`, or `candidate` — the track promotes normally up through `CEILING` but never past it, e.g. `1\.36-classic:candidate`.

- `1.36-classic` is held via the cron workflow's `--ignore-tracks` invocation (alongside the existing 1.30/31/moonray entries), not a script default.
- The "new stable upstream release" fast path, which otherwise batches edge→beta→candidate→stable in one shot bypassing purgatory, is skipped for any capped/frozen track.
- The most restrictive matching entry wins when a track matches multiple patterns, so a cap can be tightened by a more specific `--ignore-tracks` entry but never loosened.
- `:CEILING` parsing only treats a trailing bare word as a ceiling, so regexes containing a literal colon (e.g. `(?:...)`) parse as plain patterns instead of erroring.
